### PR TITLE
[FEAT] nginx를 통해 리버스 프록시를 설정한다.

### DIFF
--- a/eeos/docker-compose.yml
+++ b/eeos/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     restart: always
     networks:
       - external-network
-      - internal-network
   eeos-mysql:
     container_name: eeos-mysql
     image: mysql/mysql-server:8.0.27

--- a/eeos/docker-compose.yml
+++ b/eeos/docker-compose.yml
@@ -1,6 +1,19 @@
 version: '3.1'
 services:
-  mysql:
+  nginx-proxy:
+    container_name: nginx-proxy
+    depends_on:
+      - eeos-backend
+    image: nginx:latest
+    ports:
+      - "50001:80"
+    volumes:
+      - ./proxy/nginx.conf:/etc/nginx/nginx.conf
+    restart: always
+    networks:
+      - external-network
+      - internal-network
+  eeos-mysql:
     container_name: eeos-mysql
     image: mysql/mysql-server:8.0.27
     environment:
@@ -8,53 +21,55 @@ services:
       - MYSQL_ROOT_HOST=%
       - MYSQL_ROOT_PASSWORD=root
     command: [ "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--skip-character-set-client-handshake", "--lower_case_table_names=1", "--max_connections=2048", "--wait_timeout=3600" ]
-    ports:
-      - "13306:3306"
+    expose:
+      - "3306"
     volumes:
       - ./resources/local-develop-environment/mysql-data:/var/lib/mysql
     networks:
-      - eeos-network
-  flyway:
+      - internal-network
+  eeos-flyway:
     container_name: eeos-flyway
     image: flyway/flyway:latest
     command: -url=jdbc:mysql://eeos-mysql:3306/eeos?useSSL=false&allowPublicKeyRetrieval=true  -user=root -password=root migrate
     volumes:
-    - ./flyway/conf/:/flyway/conf
-    - ./flyway/sql/:/flyway/sql
+      - ./flyway/conf/:/flyway/conf
+      - ./flyway/sql/:/flyway/sql
     networks:
-    - eeos-network
+      - internal-network
     depends_on:
-    - mysql
-  redis:
+      - eeos-mysql
+  eeos-redis:
     container_name: eeos-redis
     image: redis:latest
-    ports:
-      - "16379:6379"
+    expose:
+      - "6379"
     environment:
       - REDIS_PASSWORD=root
     networks:
-      - eeos-network
-  backend:
+      - internal-network
+  eeos-backend:
     build:
       context: .
-      dockerfile: Dockerfile
-    container_name: eeos-app
-    ports:
-      - "8080:8080"
+      dockerfile: ./Dockerfile
+    container_name: eeos-backend
+    expose:
+      - "8080"
     depends_on:
-      - mysql
-      - flyway
-      - redis
+      - eeos-mysql
+      - eeos-flyway
+      - eeos-redis
     restart: always
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://eeos-mysql:3306/eeos?useSSL=false&serverTimezone=Asia/Seoul&useLegacyDatetimeCode=false&allowPublicKeyRetrieval=true
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root
       SPRING_PROFILES_ACTIVE: ${PROFILE}
-      SPRING_REDIS_HOST: redis
+      SPRING_REDIS_HOST: eeoes-redis
       SPRING_REDIS_PORT: 6379
       SPRING_REDIS_PASSWORD: root
-    networks: #사용할 네트워크 지정
-      - eeos-network
+    networks:
+      - external-network
+      - internal-network
 networks:
-  eeos-network:
+  external-network:
+  internal-network:

--- a/eeos/proxy/nginx.conf
+++ b/eeos/proxy/nginx.conf
@@ -1,0 +1,29 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    upstream docker-eeos-backend {
+        server eeos-backend:8080;
+    }
+
+    server {
+        listen 80;
+
+        location /api/ {
+            proxy_pass http://docker-eeos-backend/api/;
+        }
+    }
+
+    access_log  /var/log/nginx/access.log;
+    sendfile        on;
+    keepalive_timeout  65;
+}


### PR DESCRIPTION
## 연관 이슈
closed #16 

## 설명
### Nginx가 알아야 하는 것과 알면 안 되는 것 분리
* 알아야 하는 것
   *  스프링 부트
* 알지 않아도 되는 것
  - DB
  - redis
  - flyway

### docker는 각 컨테이너를 어떻게 인식할 수 있나

docker는 같은 네트워크 상에 있다면 각 컨테이너는 서비스 이름만으로도 접속할 수 있다.

그 이유는 Docker는 Service Discovery라고 하여 Docker 네트워크 상에 내부 DNS서버를 가지고 있기 때문이다.

### docker가 알아야 하는 건 같은 네트워크 상에 위치시키자.
* nginx - spring boot
  nginx 가 spring boot를 알고 있어야지 리버스 프록시를 시킬 수 있다.
* spring boot - db(mysql, redis, flway)
  마찬가지로 해당 컨테이너를 알고 있어야지 연결이 가능하다.
  
따라서 spring boot는 external, internal network에 모두 속하고
nginx는 external에만
나머지 db는 internal에만 속하도록 하였다.

### expose vs ports
기존에는 springboot, 각종 db를 ports로 하였으나 expose로 변경하였다.
그 이유는 ports는 호스트 포트와 컨테이너 포트를 연결시키는 데 사용한다.
즉, `80:8080` 이라는 뜻은
호스트에서 80으로 접속하면 이를 컨테이너의 8080포트와 연결시킨다는 의미이다.

하지만 expose는 컨테이너가 속해있는 네트워크의 포트를 여는 것이다.

따라서 eeos-backend를 예시로 들자면 external-network에서는 8080포트로 접근이 가능하지만, 호스트에서는 8080포트로 접근할 수 없다.
(즉 컨테이너 사이에서만 해당 포트로 연결할 수 있다.)

즉 호스트에서는 8080포트를 열지 않았으므로 보안상으로 이점이 있다.