### PR TITLE
[FEAT] 게스트 모드 구현

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
@@ -24,11 +24,11 @@ public class LoginConfig implements WebMvcConfigurer {
 		registry
 				.addInterceptor(memberAuthInterceptor())
 				.addPathPatterns("/api/**")
-				.excludePathPatterns("/api/auth/**", "/api/health-check");
+				.excludePathPatterns( "/api/guest/**", "/api/auth/**", "/api/health-check");
 		registry
 				.addInterceptor(reissueAuthInterceptor())
 				.addPathPatterns("/auth/reissue")
-				.excludePathPatterns("/api/auth/**", "/api/health-check");
+				.excludePathPatterns("/api/guest/**", "/api/auth/**", "/api/health-check");
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/service/ProgramService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/service/ProgramService.java
@@ -15,6 +15,7 @@ import com.blackcompany.eeos.program.application.dto.converter.ProgramResponseCo
 import com.blackcompany.eeos.program.application.dto.converter.QueryAccessRightResponseConverter;
 import com.blackcompany.eeos.program.application.event.DeletedProgramEvent;
 import com.blackcompany.eeos.program.application.exception.NotFoundProgramException;
+import com.blackcompany.eeos.program.application.model.AccessRights;
 import com.blackcompany.eeos.program.application.model.ProgramModel;
 import com.blackcompany.eeos.program.application.model.ProgramStatus;
 import com.blackcompany.eeos.program.application.model.converter.ProgramEntityConverter;
@@ -29,6 +30,7 @@ import com.blackcompany.eeos.program.application.usecase.UpdateProgramUsecase;
 import com.blackcompany.eeos.program.persistence.ProgramCategory;
 import com.blackcompany.eeos.program.persistence.ProgramEntity;
 import com.blackcompany.eeos.program.persistence.ProgramRepository;
+import com.blackcompany.eeos.program.presentation.guest.GuestAccessRights;
 import com.blackcompany.eeos.target.application.service.SelectAttendCommandTargetMemberMemberService;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -78,6 +80,14 @@ public class ProgramService
 		return responseConverter.from(
 				model, model.getProgramStatus(), findAccessRight(model, memberId));
 	}
+
+	@Override
+	public QueryProgramResponse getProgram(final Long programId) {
+		ProgramModel model = findProgram(programId);
+		return responseConverter.from(
+				model, model.getProgramStatus(), getGuestAccessRight());
+	}
+
 
 	@Override
 	@Transactional
@@ -159,5 +169,9 @@ public class ProgramService
 
 	private String findAccessRight(final ProgramModel model, final Long memberId) {
 		return model.getAccessRight(memberId);
+	}
+
+	private String getGuestAccessRight(){
+		return GuestAccessRights.get();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/GetProgramUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/GetProgramUsecase.java
@@ -13,4 +13,7 @@ public interface GetProgramUsecase {
 	 * @return
 	 */
 	QueryProgramResponse getProgram(Long memberId, Long programId);
+
+	QueryProgramResponse getProgram(Long programId);
+
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestAccessRights.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestAccessRights.java
@@ -1,6 +1,11 @@
 package com.blackcompany.eeos.program.presentation.guest;
 
-public class GuestAccessRightUtils {
-    
+import com.blackcompany.eeos.program.application.model.AccessRights;
+
+public class GuestAccessRights {
+
+    public static String get(){
+        return AccessRights.READ_ONLY.getAccessRight();
+    }
 
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestAccessRights.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestAccessRights.java
@@ -1,0 +1,6 @@
+package com.blackcompany.eeos.program.presentation.guest;
+
+public class GuestAccessRightUtils {
+    
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestProgramController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestProgramController.java
@@ -1,4 +1,4 @@
-package com.blackcompany.eeos.program.presentation;
+package com.blackcompany.eeos.program.presentation.guest;
 
 import com.blackcompany.eeos.auth.presentation.support.Member;
 import com.blackcompany.eeos.common.presentation.respnose.ApiResponse;

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestProgramController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/guest/GuestProgramController.java
@@ -1,0 +1,50 @@
+package com.blackcompany.eeos.program.presentation;
+
+import com.blackcompany.eeos.auth.presentation.support.Member;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponse;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.respnose.MessageCode;
+import com.blackcompany.eeos.program.application.dto.PageResponse;
+import com.blackcompany.eeos.program.application.dto.QueryProgramResponse;
+import com.blackcompany.eeos.program.application.dto.QueryProgramsResponse;
+import com.blackcompany.eeos.program.application.usecase.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/guest/programs")
+@Tag(name = "게스트모드 API", description = "게스트모드에 관한 API")
+public class GuestProgramController {
+    private final CreateProgramUsecase createProgramUsecase;
+    private final GetProgramUsecase getProgramUsecase;
+    private final UpdateProgramUsecase updateProgramUsecase;
+    private final GetProgramsUsecase getProgramsUsecase;
+    private final DeleteProgramUsecase deleteProgramUsecase;
+    private final GetAccessRightUsecase getAccessRightUsecase;
+
+    @Operation(summary = "행사 리스트 조회", description = "1 페이지에 들어가는 행사 리스트를 받아온다.")
+    @GetMapping()
+    public ApiResponse<SuccessBody<PageResponse<QueryProgramsResponse>>> findAll(
+            @RequestParam("category") String category,
+            @RequestParam("programStatus") String status,
+            @RequestParam("size") int size,
+            @RequestParam("page") int page) {
+        PageResponse<QueryProgramsResponse> response =
+                getProgramsUsecase.getPrograms(category, status, size, page);
+        return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+    }
+
+    @Operation(summary = "행사 조회", description = "행사 1개를 조회한다.")
+    @GetMapping("/{programId}")
+    public ApiResponse<SuccessBody<QueryProgramResponse>> findOne(
+            @PathVariable("programId") Long programId){
+        QueryProgramResponse response = getProgramUsecase.getProgram(programId);
+        return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#28 
## ✒️ 작업 내용
1. /api/guest -> url 인터셉터에서 제외
2. GuestProgramController 생성
3. ProgramService -> getGuestAccessRight() 메소드 추가
4. GuestAccessRights 클래스 생성
5. GetProgramUsecase -> getProgram(Long programId) 메소드 추가

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 
@kssumin 
기존의 코드를 크게 변경하지 않으려고, 게스트 모드로 조회시 read_only 권한을 생성해서 넣도록 했습니다.

기존의 ProgramController에서는 @Member 어노테이션으로 액세스 토큰이 존재하는지 (인터셉터 이후에도 한 번 더) 확인하더군요

GuestProgramController를 새로 만들었는데, 여기서는 @Member 어노테이션을 계속 사용할 필요가 없으므로 @Member 어노테이션은 제외하였습니다.

하지만 추후 ProgramService에서 memberId 값 없이도 동작하도록 구현해야 해서, getGuestAccessRight 메소드, GuestAccessRights 클래스를 생성하였습니다.

메소드를 새로 만들지 않고 최대한 memberId의 의존성을 낮추는 방법이 있는지 고민해봤지만 떠오르지 않았네요.

그래서 일단, ProgramService에 getProgram(Long programId) 메소드를 오버로딩하여, 새로운 로직을 추가했습니다.