### PR TITLE
[FEAT] Team 등록, 삭제, 조회기능을 구현합니다.

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/CreateTeamRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/CreateTeamRequest.java
@@ -1,0 +1,14 @@
+package com.blackcompany.eeos.team.application.dto;
+
+import com.blackcompany.eeos.common.support.dto.AbstractRequestDto;
+import javax.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class CreateTeamRequest implements AbstractRequestDto {
+	private @NotNull String teamName;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/CreateTeamResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/CreateTeamResponse.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.team.application.dto;
+
+import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class CreateTeamResponse implements AbstractResponseDto {
+	private Long teamId;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/QueryTeamResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/QueryTeamResponse.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.team.application.dto;
+
+import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class QueryTeamResponse implements AbstractResponseDto {
+	private Long teamId;
+	private String teamName;
+	private boolean teamStatus;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/QueryTeamsResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/QueryTeamsResponse.java
@@ -1,0 +1,16 @@
+package com.blackcompany.eeos.team.application.dto;
+
+import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class QueryTeamsResponse implements AbstractResponseDto {
+	private List<QueryTeamResponse> teams;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/UpdateTeamStatusRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/UpdateTeamStatusRequest.java
@@ -1,0 +1,14 @@
+package com.blackcompany.eeos.team.application.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class UpdateTeamStatusRequest {
+	private @NotNull String teamId;
+	private @NotNull Boolean teamStatus;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/CreateTeamRequestConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/CreateTeamRequestConverter.java
@@ -1,0 +1,12 @@
+package com.blackcompany.eeos.team.application.dto.converter;
+
+import com.blackcompany.eeos.team.application.dto.CreateTeamRequest;
+import com.blackcompany.eeos.team.application.model.TeamModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreateTeamRequestConverter {
+	public TeamModel from(CreateTeamRequest source) {
+		return TeamModel.builder().name(source.getTeamName()).status(true).build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/QueryTeamResponseConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/QueryTeamResponseConverter.java
@@ -1,0 +1,25 @@
+package com.blackcompany.eeos.team.application.dto.converter;
+
+import com.blackcompany.eeos.team.application.dto.QueryTeamResponse;
+import com.blackcompany.eeos.team.application.dto.QueryTeamsResponse;
+import com.blackcompany.eeos.team.application.model.TeamModel;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryTeamResponseConverter {
+	public QueryTeamResponse from(TeamModel source) {
+		return QueryTeamResponse.builder()
+				.teamId(source.getId())
+				.teamName(source.getName())
+				.teamStatus(source.isStatus())
+				.build();
+	}
+
+	public QueryTeamsResponse from(List<TeamModel> sources) {
+		return QueryTeamsResponse.builder()
+				.teams(sources.stream().map(this::from).collect(Collectors.toList()))
+				.build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/TeamResponseConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/TeamResponseConverter.java
@@ -1,0 +1,12 @@
+package com.blackcompany.eeos.team.application.dto.converter;
+
+import com.blackcompany.eeos.team.application.dto.CreateTeamResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TeamResponseConverter {
+	public CreateTeamResponse from(Long id) {
+
+		return CreateTeamResponse.builder().teamId(id).build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/UpdateTeamStatusRequestConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/dto/converter/UpdateTeamStatusRequestConverter.java
@@ -1,0 +1,12 @@
+package com.blackcompany.eeos.team.application.dto.converter;
+
+import com.blackcompany.eeos.team.application.dto.UpdateTeamStatusRequest;
+import com.blackcompany.eeos.team.application.model.TeamModel;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdateTeamStatusRequestConverter {
+	public TeamModel from(UpdateTeamStatusRequest source, TeamModel existingTeam) {
+		return existingTeam.toBuilder().status(false).build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/event/DeletedTeamEvent.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/event/DeletedTeamEvent.java
@@ -1,0 +1,13 @@
+package com.blackcompany.eeos.team.application.event;
+
+public class DeletedTeamEvent {
+	private final Long teamId;
+
+	private DeletedTeamEvent(Long teamId) {
+		this.teamId = teamId;
+	}
+
+	public static DeletedTeamEvent of(Long teamId) {
+		return new DeletedTeamEvent(teamId);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/DeniedTeamEditException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/DeniedTeamEditException.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.team.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DeniedTeamEditException extends BusinessException {
+	private static final String FAIL_CODE = "7003";
+	private final Long memberId;
+
+	public DeniedTeamEditException(Long memberId) {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+		this.memberId = memberId;
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("%s 은 팀 편집 권한(생성/삭제)이 없는 사용자 입니다.", memberId);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/DuplicateTeamNameException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/DuplicateTeamNameException.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.team.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateTeamNameException extends BusinessException {
+	private static final String FAIL_CODE = "7002";
+	private final String team_name;
+
+	public DuplicateTeamNameException(String team_name) {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+		this.team_name = team_name;
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("%s 팀은 이미 등록되어있는 팀입니다.", team_name);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/NotFoundTeamException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/NotFoundTeamException.java
@@ -1,0 +1,14 @@
+package com.blackcompany.eeos.team.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundTeamException extends BusinessException {
+	private static final String FAIL_CODE = "7000";
+	private final Long TeamId;
+
+	public NotFoundTeamException(Long teamId) {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+		this.TeamId = teamId;
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/NotFoundTeamStatusException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/exception/NotFoundTeamStatusException.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.team.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundTeamStatusException extends BusinessException {
+	private static final String FAIL_CODE = "7001";
+	private final String status;
+
+	public NotFoundTeamStatusException(String status) {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+		this.status = status;
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("%s는 올바르지 않는 형식의 팀 상태 입니다.", status);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/model/TeamModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/model/TeamModel.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.team.application.model;
+
+import com.blackcompany.eeos.common.support.AbstractModel;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+/** 빌더가 만들어지는 조건 1. 생성자가 있어야 한다. 2. 어떤 생성자인가? -> 필드의 타입을 모두 매개변수로 받는 생성자가 하나 있어야 한다. */
+public class TeamModel implements AbstractModel {
+
+	private Long id;
+	private String name;
+	private boolean status;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/model/converter/TeamEntityConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/model/converter/TeamEntityConverter.java
@@ -1,0 +1,24 @@
+package com.blackcompany.eeos.team.application.model.converter;
+
+import com.blackcompany.eeos.common.support.converter.AbstractEntityConverter;
+import com.blackcompany.eeos.team.application.model.TeamModel;
+import com.blackcompany.eeos.team.persistence.TeamEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TeamEntityConverter implements AbstractEntityConverter<TeamEntity, TeamModel> {
+
+	@Override
+	public TeamEntity toEntity(TeamModel source) {
+		return TeamEntity.builder().name(source.getName()).status(source.isStatus()).build();
+	}
+
+	@Override
+	public TeamModel from(TeamEntity source) {
+		return TeamModel.builder()
+				.id(source.getId())
+				.name(source.getName())
+				.status((source.isStatus()))
+				.build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/usecase/CreateTeamUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/usecase/CreateTeamUsecase.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.team.application.usecase;
+
+import com.blackcompany.eeos.team.application.dto.CreateTeamRequest;
+import com.blackcompany.eeos.team.application.dto.CreateTeamResponse;
+
+public interface CreateTeamUsecase {
+	CreateTeamResponse create(Long memberId, CreateTeamRequest request);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/usecase/DeleteTeamUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/usecase/DeleteTeamUsecase.java
@@ -1,0 +1,5 @@
+package com.blackcompany.eeos.team.application.usecase;
+
+public interface DeleteTeamUsecase {
+	void delete(Long memberId, Long teamId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/usecase/GetTeamsByActiveStatus.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/usecase/GetTeamsByActiveStatus.java
@@ -1,0 +1,7 @@
+package com.blackcompany.eeos.team.application.usecase;
+
+import com.blackcompany.eeos.team.application.dto.QueryTeamsResponse;
+
+public interface GetTeamsByActiveStatus {
+	QueryTeamsResponse execute(String programId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/persistence/TeamEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/persistence/TeamEntity.java
@@ -1,0 +1,43 @@
+package com.blackcompany.eeos.team.persistence;
+
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import javax.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(
+		name = TeamEntity.ENTITY_PREFIX,
+		indexes = {
+			@Index(name = "idx_team_name", columnList = "team_name"),
+			@Index(name = "idx_team_status", columnList = "team_status")
+		})
+// @Where(clause = "status=1")
+/** status=1, 현학기 활동 팀 status=0, 현학기 활동 팀 X */
+public class TeamEntity extends BaseEntity {
+	public static final String ENTITY_PREFIX = "team";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(unique = true, name = ENTITY_PREFIX + "_name", nullable = false)
+	private String name;
+
+	@Column(
+			name = ENTITY_PREFIX + "_status",
+			nullable = false,
+			columnDefinition = "boolean default 1")
+	@Builder.Default
+	private boolean status = true; // 현학기 활동팀 1, 아니면 0
+
+	public void updateTeamStatus(boolean status) {
+		this.status = status;
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/persistence/TeamRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/persistence/TeamRepository.java
@@ -1,0 +1,22 @@
+package com.blackcompany.eeos.team.persistence;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+
+	@Query("SELECT T FROM TeamEntity T WHERE T.name =:teamName")
+	List<TeamEntity> findTeamEntityByName(@Param("teamName") String teamName);
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE TeamEntity T SET T.status=false where T.id=:teamId")
+	void deleteTeamEntityByName(@Param("teamId") Long teamId);
+
+	@Query("SELECT T FROM TeamEntity T WHERE T.status = true order by T.name")
+	List<TeamEntity> findAllTeamsByStatus();
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/team/presetation/TeamController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/presetation/TeamController.java
@@ -1,0 +1,55 @@
+package com.blackcompany.eeos.team.presetation;
+
+import com.blackcompany.eeos.auth.presentation.support.Member;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponse;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.common.presentation.respnose.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.respnose.MessageCode;
+import com.blackcompany.eeos.team.application.dto.CreateTeamRequest;
+import com.blackcompany.eeos.team.application.dto.CreateTeamResponse;
+import com.blackcompany.eeos.team.application.dto.QueryTeamsResponse;
+import com.blackcompany.eeos.team.application.usecase.CreateTeamUsecase;
+import com.blackcompany.eeos.team.application.usecase.DeleteTeamUsecase;
+import com.blackcompany.eeos.team.application.usecase.GetTeamsByActiveStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/teams")
+@Tag(name = "API", description = "팀생성에 관한 API")
+public class TeamController {
+
+	private final CreateTeamUsecase createTeamUsecase;
+	private final DeleteTeamUsecase deleteTeamUsecase;
+
+	private final GetTeamsByActiveStatus getTeamsByActiveStatus;
+
+	@Operation(summary = "팀생성", description = "ReqeustBody에 담긴 팀이름으로 팀을 생성한다.")
+	@PostMapping
+	public ApiResponse<SuccessBody<CreateTeamResponse>> create(
+			@Member Long memberId, @RequestBody @Valid CreateTeamRequest request) {
+		CreateTeamResponse response = createTeamUsecase.create(memberId, request);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.CREATE);
+	}
+
+	@Operation(summary = "팀 삭제", description = "Pathvariable의 teamId을 사용해서 팀을 삭제한다.")
+	@DeleteMapping("/{teamId}")
+	public ApiResponse<SuccessBody<Void>> delete(
+			@Member Long memberId, @PathVariable("teamId") Long teamId) {
+		deleteTeamUsecase.delete(memberId, teamId);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
+	}
+
+	@Operation(summary = "팀 리스트 조회", description = "현학기 활동팀 리스트를 가져온다.")
+	@GetMapping
+	public ApiResponse<SuccessBody<QueryTeamsResponse>> findTeamsByActiveStatus(
+			@RequestParam("programId") String programId) {
+		QueryTeamsResponse response = getTeamsByActiveStatus.execute(programId);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈
#77 
## ✒️ 작업 내용
팀등록, 삭제, 조회 기능을 구현했습니다.
- 새로만든 클래스
  - CreateTeamRequest/Response
  - QueryTeamResponse
  - QueryTeamsResponse
  - UpdateTeamStatusRequest
  - DeletedTeamEvent
  - DeniedTeamEditException
  - DuplicateTeamNameException
  - NotFoundTeamException
  - NotFoundTeamStatusException
  - TeamEntityConverter
  - TeamModel
  - TeamService
  - CreateTeamUsecase
  - DeleteTeamUsecase
  - GetTeamsByActiveStatus
  - TeamEntity
  - TeamRepository
  - TeamController
### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 
- programId 가 none 인 경우 활동 상태가 1인 모든 팀을 불러오고,
- programId 가 숫자 인경우 해당 programId에 등록된 팀을 불러오기로 회의가 되었습니다
- TeamService 의 execute 에는 ProgramId가 none 인 경우에 해당하는 로직이 작성되어있는데,
- programId가 유효한 숫자인경우, none 인경우, 올바르지 않은 형식인 경우 이 세가지 경우를 구별할 수 있는 방법에 대해 리뷰어 분들의 의견이 궁금합니다!
- (제가 생각한 코드는 주석으로 넣어뒀습니다)
