### PR TITLE
[UPDATE] Team CRUD, 관리자 검사 로직 최적화

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/model/MemberModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/model/MemberModel.java
@@ -28,6 +28,10 @@ public class MemberModel implements AbstractModel, MemberIdModel {
 		return this;
 	}
 
+	public boolean isAdmin(){
+		return this.name.equals(Name.ADMIN_NAME.getName());
+	}
+
 	public boolean validateSame(Long memberId) {
 		return id.equals(memberId);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/model/Name.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/model/Name.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.member.application.model;
+
+import lombok.Getter;
+
+@Getter
+public enum Name {
+
+    ADMIN_NAME("00기 관리자");
+
+    private final String name;
+
+    Name(String name){
+        this.name = name;
+    }
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/QueryMemberService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/QueryMemberService.java
@@ -22,6 +22,7 @@ public class QueryMemberService implements GetMembersByActiveStatus, GetMemberBy
 	private final MemberEntityConverter entityConverter;
 	private final MemberRepository memberRepository;
 	private final QueryMemberResponseConverter responseConverter;
+	private final MemberEntityConverter memberEntityConverter;
 
 	@Override
 	public QueryMembersResponse execute(final String activeStatus) {
@@ -43,6 +44,12 @@ public class QueryMemberService implements GetMembersByActiveStatus, GetMemberBy
 
 		MemberModel model = entityConverter.from(member);
 		return responseConverter.from(model);
+	}
+
+	public MemberModel findMember(Long memberId){
+		MemberEntity entity = memberRepository.findById(memberId)
+				.orElseThrow(NotFoundMemberException::new);
+		return memberEntityConverter.from(entity);
 	}
 
 	public String getName(final Long memberId) {

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/Service/TeamService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/Service/TeamService.java
@@ -1,5 +1,8 @@
 package com.blackcompany.eeos.team.application.Service;
 
+import com.blackcompany.eeos.common.support.AdminChecker;
+import com.blackcompany.eeos.member.application.model.Name;
+import com.blackcompany.eeos.member.application.service.QueryMemberService;
 import com.blackcompany.eeos.team.application.dto.CreateTeamRequest;
 import com.blackcompany.eeos.team.application.dto.CreateTeamResponse;
 import com.blackcompany.eeos.team.application.dto.QueryTeamsResponse;
@@ -39,22 +42,22 @@ public class TeamService implements CreateTeamUsecase, DeleteTeamUsecase, GetTea
 	private final TeamResponseConverter teamResponseConverter;
 	private final ApplicationEventPublisher applicationEventPublisher;
 	private final QueryTeamResponseConverter queryTeamResponseConverter;
+	private final AdminChecker adminChecker;
+	private final QueryMemberService memberService;
 
 	@Override
 	@Transactional
 	public CreateTeamResponse create(final Long memberId, final CreateTeamRequest request) {
-		isAdmin(memberId);
+		validateMember(memberId);
 		TeamModel model = createTeamRequestConverter.from(request);
 		Long saveId = createTeam(model);
 
 		return teamResponseConverter.from(saveId);
 	}
 
-	public void isAdmin(Long memberId) {
-		if (memberId == 4) {
-			return;
-		}
-		throw new DeniedTeamEditException(memberId);
+	private void validateMember(Long memberId) {
+		if(!memberService.findMember(memberId).isAdmin())
+			throw new DeniedTeamEditException(memberId);
 	}
 
 	private Long createTeam(TeamModel model) {

--- a/eeos/src/main/java/com/blackcompany/eeos/team/application/Service/TeamService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/team/application/Service/TeamService.java
@@ -99,7 +99,7 @@ public class TeamService implements CreateTeamUsecase, DeleteTeamUsecase, GetTea
 	@Transactional
 	public void delete(final Long memberId, final Long teamId) {
 		TeamModel team = findTeam(teamId);
-		isAdmin(memberId);
+		validateMember(memberId);
 
 		teamRepository.deleteTeamEntityByName(team.getId());
 		applicationEventPublisher.publishEvent(DeletedTeamEvent.of(teamId));


### PR DESCRIPTION
## 📌 관련 이슈
#77 

## ✒️ 작업 내용
관리자인지 검사하는 로직을 DB에 저장된 Member의 정보를 비교해 확인하도록 하는 로직으로 변경하였습니다.

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 

