### PR TITLE
[FEAT] 회원 이전 출석 정보 확인 로직 수정

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/model/AttendModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/model/AttendModel.java
@@ -72,13 +72,13 @@ public class AttendModel implements AbstractModel, MemberIdModel {
 			throw new DeniedSaveAttendException();
 		}
 
-		if(!AttendStatus.isSame(status.getStatus(), AttendStatus.NONRESPONSE)) {
+		if (!AttendStatus.isSame(status.getStatus(), AttendStatus.NONRESPONSE)) {
 			throw new DeniedChangeAttendException();
 		}
 	}
 
 	private void isSameBeforeStatus(String status) {
-		if (AttendStatus.isSame(status, this.status)) {
+		if (!AttendStatus.isSame(status, this.status)) {
 			return;
 		}
 		throw new NotSameBeforeAttendStatusException(memberId);

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/AttendController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/AttendController.java
@@ -17,13 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/AttendController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/AttendController.java
@@ -46,7 +46,7 @@ public class AttendController {
 	@Operation(
 			summary = "참여상태 변경",
 			description = "PathVariable의 programId와 RequestBody의 참여상태를 이용하여 사용자의 참여상태를 변경한다.")
-	@PutMapping("/attend/programs/{programId}")
+	@PostMapping("/attend/programs/{programId}")
 	public ApiResponse<SuccessBody<ChangeAttendStatusResponse>> changeAttendStatus(
 			@Member Long memberId,
 			@PathVariable("programId") Long programId) {


### PR DESCRIPTION
## 📌 관련 이슈
#86 

## ✒️ 작업 내용
- 회원이 출석할 때, 이전 출석 정보와 이후 출석 정보를 비교하는 로직을 수정합니다.

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 

