### PR TITLE
[FEAT] oauth_member 삭제 로직 추가

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/CommandMemberService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/CommandMemberService.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.member.application.service;
 
+import com.blackcompany.eeos.auth.persistence.OAuthMemberRepository;
 import com.blackcompany.eeos.member.application.dto.ChangeActiveStatusRequest;
 import com.blackcompany.eeos.member.application.dto.CommandMemberResponse;
 import com.blackcompany.eeos.member.application.dto.converter.CommandMemberResponseConverter;
@@ -23,6 +24,8 @@ public class CommandMemberService implements ChangeActiveStatusUsecase {
 	private final MemberEntityConverter memberConverter;
 	private final CommandMemberResponseConverter responseConverter;
 	private final ApplicationEventPublisher applicationEventPublisher;
+
+	private final OAuthMemberRepository oAuthMemberRepository;
 
 	@Transactional
 	@Override
@@ -83,6 +86,8 @@ public class CommandMemberService implements ChangeActiveStatusUsecase {
 		isAdmin(adminMemberId);
 
 		memberRepository.deleteById(member.getId());
+		oAuthMemberRepository.deleteById(member.getId());
+
 		applicationEventPublisher.publishEvent(DeletedMemberEvent.of(memberId));
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈
#110 
## ✒️ 작업 내용
member soft delete는 수행하지 않도록 했습니다.
멤버 삭제시 로그인이 되는 이슈를 해결하기 위해 oauth_member 도 함께 삭제하는 로직을 추가하였습니다~!
### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 

