### PR TITLE
[FIX] Notification 관련 CI workflow 에러 해결

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -24,27 +24,42 @@ jobs:
         echo 'SLACK_IDS=${{ toJson(secrets.SLACK_IDS) }}' >> $GITHUB_ENV
       shell: bash
     - name: Send Slack notification for new PR
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        set -e
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"
-        REVIEWERS='${{ toJson(github.event.pull_request.requested_reviewers.*.login) }}'
+        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+        REVIEWERS='${{ toJson(github.event.pull_request.requested_reviewers) }}'
         
-        if [ -z "$REVIEWERS" ] || [ "$REVIEWERS" == "null" ]; then
+        if [ "$REVIEWERS" == "null" ] || [ "$REVIEWERS" == "[]" ]; then
           echo "No reviewers requested for this PR"
           exit 0
         fi
         
-        echo "Reviewers: $REVIEWERS"
+        # Parse SLACK_IDS as JSON
+        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
+        if [ "$SLACK_IDS_JSON" == "{}" ]; then
+          echo "Warning: SLACK_IDS is not a valid JSON. Attempting to parse as a string."
+          SLACK_IDS_JSON=$(echo "$SLACK_IDS" | sed 's/^"//; s/"$//' | jq -R 'split(",") | map(split(":")) | from_entries' 2>/dev/null || echo "{}")
+          if [ "$SLACK_IDS_JSON" == "{}" ]; then
+            echo "Error: Failed to parse SLACK_IDS as JSON or string. Please check the format."
+            exit 1
+          fi
+        fi
         
-        parse_slack_ids() {
-          echo "$SLACK_IDS" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
+        get_slack_id() {
+          local github_username="$1"
+          echo "$SLACK_IDS_JSON" | jq -r --arg user "$github_username" '.[$user] // empty'
         }
         
-        reviewers=$(echo "$REVIEWERS" | jq -r '.[]')
+        reviewers=$(echo "$REVIEWERS" | jq -r '.[].login // empty')
         mentions=""
         
         for reviewer in $reviewers; do
-          slack_id=$(parse_slack_ids | grep "^$reviewer:" | cut -d':' -f2)
+          slack_id=$(get_slack_id "$reviewer")
           
           if [ -n "$slack_id" ]; then
             mentions="$mentions <@$slack_id>"
@@ -54,10 +69,16 @@ jobs:
           fi
         done
         
-        echo "Mentions: $mentions"
+        author_slack_id=$(get_slack_id "$PR_AUTHOR")
+        if [ -n "$author_slack_id" ]; then
+          author_mention="<@$author_slack_id>"
+        else
+          author_mention="$PR_AUTHOR"
+          echo "Warning: No Slack ID found for PR author $PR_AUTHOR" >&2
+        fi
         
         if [ -n "$mentions" ]; then
-          message="$mentions 님, 새로운 PR이 생성되었습니다: <$PR_URL|$PR_TITLE>"
+          message="$mentions 님, $author_mention 님이 새로운 PR을 생성하였습니다: <$PR_URL|$PR_TITLE>"
           response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
             --data "{\"text\":\"$message\"}" \
             "$SLACK_WEBHOOK_URL")
@@ -71,5 +92,3 @@ jobs:
         else
           echo "No reviewers to notify"
         fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -2,10 +2,8 @@ name: PR Slack Notification
 on:
   pull_request:
     types: [opened, reopened]
-
 permissions:
   pull-requests: read
-
 jobs:
   notify_reviewers:
     runs-on: ubuntu-latest
@@ -20,12 +18,11 @@ jobs:
           echo "Error: SLACK_IDS is not set"
           exit 1
         fi
-
     - name: Set environment variables
       run: |
         echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}" >> $GITHUB_ENV
-        echo "SLACK_IDS=${{ secrets.SLACK_IDS }}" >> $GITHUB_ENV
-
+        echo 'SLACK_IDS=${{ toJson(secrets.SLACK_IDS) }}' >> $GITHUB_ENV
+      shell: bash
     - name: Send Slack notification for new PR
       run: |
         PR_TITLE="${{ github.event.pull_request.title }}"
@@ -40,10 +37,6 @@ jobs:
         echo "Reviewers: $REVIEWERS"
         
         parse_slack_ids() {
-          if ! echo "$SLACK_IDS" | jq empty; then
-            echo "Error: Invalid JSON in SLACK_IDS" >&2
-            exit 1
-          fi
           echo "$SLACK_IDS" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
         }
         

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -11,38 +11,45 @@ jobs:
     steps:
     - name: PR 리뷰 시 Slack 알림 보내기
       run: |
+        set -e
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"
         PR_AUTHOR="${{ github.event.pull_request.user.login }}"
         REVIEW_STATE="${{ github.event.review.state }}"
         REVIEWER="${{ github.event.review.user.login }}"
         
-        echo "SLACK_IDS 내용:"
-        echo "$SLACK_IDS"
-        
-        # SLACK_IDS를 JSON 문자열로 처리
-        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -R '.' | jq 'fromjson')
-        
-        if [ $? -ne 0 ]; then
-          echo "오류: SLACK_IDS가 유효한 JSON 형식이 아닙니다. 시크릿 형식을 확인해주세요." >&2
-          exit 1
+        # Parse SLACK_IDS as JSON
+        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
+        if [ "$SLACK_IDS_JSON" == "{}" ]; then
+          echo "Warning: SLACK_IDS is not a valid JSON. Attempting to parse as a string."
+          SLACK_IDS_JSON=$(echo "$SLACK_IDS" | sed 's/^"//; s/"$//' | jq -R 'split(",") | map(split(":")) | from_entries' 2>/dev/null || echo "{}")
+          if [ "$SLACK_IDS_JSON" == "{}" ]; then
+            echo "Error: Failed to parse SLACK_IDS as JSON or string. Please check the format."
+            exit 1
+          fi
         fi
         
-        echo "파싱된 SLACK_IDS:"
-        echo "$SLACK_IDS_JSON"
-        
         get_slack_id() {
-          echo "$SLACK_IDS_JSON" | jq -r --arg github_user "$1" '.[$github_user] // empty'
+          local github_username="$1"
+          echo "$SLACK_IDS_JSON" | jq -r --arg user "$github_username" '.[$user] // empty'
         }
         
         author_slack_id=$(get_slack_id "$PR_AUTHOR")
         reviewer_slack_id=$(get_slack_id "$REVIEWER")
         
-        author_mention="${author_slack_id:+<@$author_slack_id>}"
-        reviewer_mention="${reviewer_slack_id:+<@$reviewer_slack_id>}"
+        if [ -n "$author_slack_id" ]; then
+          author_mention="<@$author_slack_id>"
+        else
+          author_mention="$PR_AUTHOR"
+          echo "Warning: No Slack ID found for PR author $PR_AUTHOR" >&2
+        fi
         
-        author_mention="${author_mention:-$PR_AUTHOR}"
-        reviewer_mention="${reviewer_mention:-$REVIEWER}"
+        if [ -n "$reviewer_slack_id" ]; then
+          reviewer_mention="<@$reviewer_slack_id>"
+        else
+          reviewer_mention="$REVIEWER"
+          echo "Warning: No Slack ID found for reviewer $REVIEWER" >&2
+        fi
         
         case "$REVIEW_STATE" in
           "changes_requested")
@@ -56,17 +63,17 @@ jobs:
             ;;
         esac
         
-        if [ ! -z "$message" ]; then
+        if [ -n "$message" ]; then
           response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
             --data "{\"text\":\"$message\"}" \
             "$SLACK_WEBHOOK_URL")
           
           if [ "$response" = "200" ]; then
-            echo "Slack 알림을 성공적으로 보냈습니다: $message"
+            echo "Successfully sent Slack notification"
           else
-            echo "오류: Slack 알림 전송에 실패했습니다. HTTP 상태 코드: $response" >&2
+            echo "Error: Failed to send Slack notification. HTTP status code: $response" >&2
             exit 1
           fi
         else
-          echo "보낼 알림이 없습니다"
+          echo "No notification to send"
         fi

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -17,30 +17,25 @@ jobs:
         REVIEW_STATE="${{ github.event.review.state }}"
         REVIEWER="${{ github.event.review.user.login }}"
         
-        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -R '.' | jq '.')
+        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -R 'fromjson')
         
         if [ $? -ne 0 ]; then
+          echo "Error parsing SLACK_IDS JSON"
           exit 1
         fi
         
-        parse_slack_ids() {
-            echo "$SLACK_IDS_JSON" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
+        get_slack_id() {
+          echo "$SLACK_IDS_JSON" | jq -r --arg github_user "$1" '.[$github_user] // empty'
         }
         
-        author_slack_id=$(parse_slack_ids | grep "^$PR_AUTHOR:" | cut -d':' -f2)
-        reviewer_slack_id=$(parse_slack_ids | grep "^$REVIEWER:" | cut -d':' -f2)
+        author_slack_id=$(get_slack_id "$PR_AUTHOR")
+        reviewer_slack_id=$(get_slack_id "$REVIEWER")
         
-        if [ -n "$author_slack_id" ]; then
-            author_mention="<@$author_slack_id>"
-        else
-            author_mention="$PR_AUTHOR"
-        fi
+        author_mention="${author_slack_id:+<@$author_slack_id>}"
+        reviewer_mention="${reviewer_slack_id:+<@$reviewer_slack_id>}"
         
-        if [ -n "$reviewer_slack_id" ]; then
-            reviewer_mention="<@$reviewer_slack_id>"
-        else
-            reviewer_mention="$REVIEWER"
-        fi
+        author_mention="${author_mention:-$PR_AUTHOR}"
+        reviewer_mention="${reviewer_mention:-$REVIEWER}"
         
         case "$REVIEW_STATE" in
           "changes_requested")
@@ -60,6 +55,7 @@ jobs:
             "$SLACK_WEBHOOK_URL")
           
           if [ "$response" != "200" ]; then
+            echo "Error sending Slack notification. HTTP status code: $response"
             exit 1
           fi
         fi

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -1,0 +1,65 @@
+name: PR Review Slack Notification
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  notify_pr_author:
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_REVIEW_WEBHOOK_URL }}
+      SLACK_IDS: ${{ secrets.SLACK_IDS }}
+    steps:
+    - name: PR 리뷰 시 Slack 알림 보내기
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+        REVIEW_STATE="${{ github.event.review.state }}"
+        REVIEWER="${{ github.event.review.user.login }}"
+        
+        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -R '.' | jq '.')
+        
+        if [ $? -ne 0 ]; then
+          exit 1
+        fi
+        
+        parse_slack_ids() {
+            echo "$SLACK_IDS_JSON" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
+        }
+        
+        author_slack_id=$(parse_slack_ids | grep "^$PR_AUTHOR:" | cut -d':' -f2)
+        reviewer_slack_id=$(parse_slack_ids | grep "^$REVIEWER:" | cut -d':' -f2)
+        
+        if [ -n "$author_slack_id" ]; then
+            author_mention="<@$author_slack_id>"
+        else
+            author_mention="$PR_AUTHOR"
+        fi
+        
+        if [ -n "$reviewer_slack_id" ]; then
+            reviewer_mention="<@$reviewer_slack_id>"
+        else
+            reviewer_mention="$REVIEWER"
+        fi
+        
+        case "$REVIEW_STATE" in
+          "changes_requested")
+            message="$author_mention님, $reviewer_mention님이 PR에 변경을 요청했습니다: <$PR_URL|$PR_TITLE>"
+            ;;
+          "commented")
+            message="$author_mention님, $reviewer_mention님이 PR에 댓글을 달았습니다: <$PR_URL|$PR_TITLE>"
+            ;;
+          "approved")
+            message="$author_mention님, 축하합니다! $reviewer_mention님이 PR을 승인했습니다: <$PR_URL|$PR_TITLE>"
+            ;;
+        esac
+        
+        if [ ! -z "$message" ]; then
+          response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"$message\"}" \
+            "$SLACK_WEBHOOK_URL")
+          
+          if [ "$response" != "200" ]; then
+            exit 1
+          fi
+        fi

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -17,12 +17,19 @@ jobs:
         REVIEW_STATE="${{ github.event.review.state }}"
         REVIEWER="${{ github.event.review.user.login }}"
         
-        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -R 'fromjson')
+        echo "SLACK_IDS 내용:"
+        echo "$SLACK_IDS"
+        
+        # SLACK_IDS를 JSON 문자열로 처리
+        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -R '.' | jq 'fromjson')
         
         if [ $? -ne 0 ]; then
-          echo "Error parsing SLACK_IDS JSON"
+          echo "오류: SLACK_IDS가 유효한 JSON 형식이 아닙니다. 시크릿 형식을 확인해주세요." >&2
           exit 1
         fi
+        
+        echo "파싱된 SLACK_IDS:"
+        echo "$SLACK_IDS_JSON"
         
         get_slack_id() {
           echo "$SLACK_IDS_JSON" | jq -r --arg github_user "$1" '.[$github_user] // empty'
@@ -54,8 +61,12 @@ jobs:
             --data "{\"text\":\"$message\"}" \
             "$SLACK_WEBHOOK_URL")
           
-          if [ "$response" != "200" ]; then
-            echo "Error sending Slack notification. HTTP status code: $response"
+          if [ "$response" = "200" ]; then
+            echo "Slack 알림을 성공적으로 보냈습니다: $message"
+          else
+            echo "오류: Slack 알림 전송에 실패했습니다. HTTP 상태 코드: $response" >&2
             exit 1
           fi
+        else
+          echo "보낼 알림이 없습니다"
         fi


### PR DESCRIPTION
## 📌 관련 이슈
closed #142 

## ✒️ 작업 내용
### PR 발생 시 알람 CI
* 기존 pr-notification ci에서는 SLACK_IDS값(깃허브 - slack member id를 key-value로 연관지은 값)을 json형태로 관리하고 있습니다.
* 하지만 CI에서 해당 값을 불러올 때 json으로 명확하게 불러오지 않아서 에러가 발생한 것 같아 toJSON을 통해 명시적으로 json으로 변환했습니다.
* 추가적으로 assingees, reviewers를 지정할 떄 해당 멤버를 슬랙에서 태그하도록 했습니다.

### 리뷰 발생 시 알람 CI
리뷰가 발생했을 때 CI도 추가해두었습니다. 


### 스크린샷 🏞️ (선택)
<img width="626" alt="image" src="https://github.com/user-attachments/assets/45aa9720-431d-4e8c-a168-9e86269589e0">


## 💬 REVIEWER에게 요구사항 💬 
현재 backend-ci가 통과하지 않을 것입니다(이는 #143 이슈에서 해결합니다.)
따라서 notification 관련 CI만 해당 PR에서 통과하면 merge 해도 될 것 같습니다!
