### PR TITLE
[FIX] 행사 수정 및 출석체크 상태 변경이 안되는 오류 수정

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/model/converter/ProgramRequestConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/model/converter/ProgramRequestConverter.java
@@ -40,6 +40,7 @@ public class ProgramRequestConverter
 				.id(programId)
 				.title(source.getTitle())
 				.content(source.getContent())
+				.githubUrl(source.getProgramGithubUrl())
 				.programDate(DateConverter.toEpochSecond(source.getDeadLine()))
 				.programCategory(ProgramCategory.find(source.getCategory()))
 				.programType(ProgramType.find(source.getType()))

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/model/AttendModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/model/AttendModel.java
@@ -35,6 +35,14 @@ public class AttendModel implements AbstractModel, MemberIdModel {
 		return status.getStatus();
 	}
 
+	public boolean isAttended(){
+		return (!this.status.equals(AttendStatus.NONRESPONSE) && !this.status.equals(AttendStatus.NONRELATED));
+	}
+
+	public boolean isRelated() {
+		return !this.status.equals(AttendStatus.NONRELATED);
+	}
+
 	public static AttendModel of() {
 		return AttendModel.builder().status(AttendStatus.NONRELATED).build();
 	}
@@ -52,22 +60,11 @@ public class AttendModel implements AbstractModel, MemberIdModel {
 	}
 
 	private void validateChange(String afterStatus) {
-		canChange();
 		isSameBeforeStatus(afterStatus);
 	}
 
 	private void validateChangeByManager(String beforeStatus) {
 		isSameBeforeStatus(beforeStatus);
-	}
-
-	private void canChange() {
-		if (AttendStatus.isSame(status.getStatus(), AttendStatus.NONRELATED)) {
-			throw new DeniedSaveAttendException();
-		}
-
-		if (!AttendStatus.isSame(status.getStatus(), AttendStatus.NONRESPONSE)) {
-			throw new DeniedChangeAttendException();
-		}
 	}
 
 	private void isSameBeforeStatus(String status) {

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -132,7 +132,7 @@ public class AttendService
 	private void validateAttend(ProgramModel programModel, AttendModel attendModel) {
 		if (programModel.getAttendMode().equals(ProgramAttendMode.END)) throw new NotStartAttendException();
 		if(attendModel.isAttended()) throw new DeniedChangeAttendException();
-		if(attendModel.isRelated()) throw new DeniedSaveAttendException();
+		if(!attendModel.isRelated()) throw new DeniedSaveAttendException();
 	}
 
 	private ProgramModel findProgram(final Long programId) {

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -20,6 +20,8 @@ import com.blackcompany.eeos.target.application.dto.converter.AttendInfoConverte
 import com.blackcompany.eeos.target.application.dto.converter.ChangeAttendStatusConverter;
 import com.blackcompany.eeos.target.application.dto.converter.QueryAttendActiveStatusConverter;
 import com.blackcompany.eeos.target.application.dto.converter.QueryAttendStatusResponseConverter;
+import com.blackcompany.eeos.target.application.exception.DeniedChangeAttendException;
+import com.blackcompany.eeos.target.application.exception.DeniedSaveAttendException;
 import com.blackcompany.eeos.target.application.exception.NotFoundAttendException;
 import com.blackcompany.eeos.target.application.exception.NotStartAttendException;
 import com.blackcompany.eeos.target.application.model.AttendModel;
@@ -88,7 +90,10 @@ public class AttendService
 	@Override
 	public ChangeAttendStatusResponse changeStatus(final Long memberId, final Long programId) {
 		AttendModel model = getAttend(memberId, programId);
+
 		ProgramModel program = findProgram(programId);
+
+		validateAttend(program, model);
 
 		AttendModel changedModel = model.changeStatus(program.getAttendMode().getMode());
 
@@ -124,8 +129,10 @@ public class AttendService
 		return queryAttendActiveStatusConverter.of(response);
 	}
 
-	private void validateAttend(ProgramModel model) {
-		if (model.getAttendMode().equals(ProgramAttendMode.END)) throw new NotStartAttendException();
+	private void validateAttend(ProgramModel programModel, AttendModel attendModel) {
+		if (programModel.getAttendMode().equals(ProgramAttendMode.END)) throw new NotStartAttendException();
+		if(attendModel.isAttended()) throw new DeniedChangeAttendException();
+		if(attendModel.isRelated()) throw new DeniedSaveAttendException();
 	}
 
 	private ProgramModel findProgram(final Long programId) {


### PR DESCRIPTION
## 📌 관련 이슈
#169 

## ✒️ 작업 내용
- 관리자가 회원들의 출석 상태를 변경할 경우
  - 최소한의 검증만 수행하고, 상태 변경
- 일반 회원이 출석 상태를 변경할 경우
  - 행사 참석의 대상인지 검증
  - 이미 출석체크를 진행하였는지 검증

비즈니스 규칙이라고 판단되어, Model 에 로직을 작성하지 않고, Service에 로직을 작성

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 

