### PR TITLE
[FEAT] 이전 도메인으로 요청이 들어왔을 때 리다이렉트 처리

### DIFF
--- a/eeos/proxy/nginx.conf
+++ b/eeos/proxy/nginx.conf
@@ -18,14 +18,14 @@ http {
     # 기존 도메인(.store)에 대한 리다이렉트
     server {
         listen 80;
-        server_name eeos.econo.store;
-        return 301 http://eeos.econo.co.kr$request_uri;
+        server_name eeos.store;
+        return 301 http://eeos.co.kr$request_uri;
     }
 
     # 새 도메인(.co.kr) 처리
     server {
         listen 80;
-        server_name eeos.econo.co.kr;
+        server_name eeos.co.kr;
 
         location /api/ {
             proxy_pass http://docker-eeos-backend/api/;

--- a/eeos/proxy/nginx.conf
+++ b/eeos/proxy/nginx.conf
@@ -15,11 +15,23 @@ http {
         server eeos-backend:8080;
     }
 
+    # 기존 도메인(.store)에 대한 리다이렉트
     server {
         listen 80;
+        server_name eeos.econo.store;
+        return 301 http://eeos.econo.co.kr$request_uri;
+    }
+
+    # 새 도메인(.co.kr) 처리
+    server {
+        listen 80;
+        server_name eeos.econo.co.kr;
 
         location /api/ {
             proxy_pass http://docker-eeos-backend/api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
closed #173 

## ✒️ 작업 내용
Nginx 설정에서 도메인 리다이렉트 및 프록시 헤더 추가

### 주요 변경점
1. eeos.store → eeos.co.kr 도메인 리다이렉트 설정 추가
   ```nginx
   server {
       listen 80;
       server_name eeos.store;
       return 301 http://eeos.co.kr$request_uri;
   }
   ```

2. 새로운 도메인(eeos.co.kr)에 대한 서버 블록 추가 및 프록시 헤더 설정
   - Host, X-Real-IP, X-Forwarded-For 헤더 추가로 백엔드에서 실제 클라이언트 정보 확인 가능
   ```nginx
   server {
       listen 80;
       server_name eeos.co.kr;
       location /api/ {
           proxy_pass http://docker-eeos-backend/api/;
           proxy_set_header Host $host;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       }
   }
   ```

### 영향
- 사용자들이(프론트) 이전 도메인(eeos.store)으로 요청을 보내도 자동으로 새 도메인으로 리다이렉트됨
- 백엔드에서 실제 클라이언트 IP 및 요청 경로 확인 가능

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 
* CI는 이전 PR을 보면 lint가 안맞아서 발생하고 있습니다...(앞으론 !!! CI 통과하면 merge 해주세요 !! 이거 강제할 수 있는 방법 찾아볼게요)
* 이번 PR에서 lint 문제는 해결하지 않고 별도의 PR을 통해서 해결합니다.
