### PR TITLE
[BUG] 쿠키 이름 환경별 별도로 설정

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.auth.presentation;
 
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.presentation.interceptor.AuthInterceptor;
+import com.blackcompany.eeos.auth.presentation.support.CookieNameFormatter;
 import com.blackcompany.eeos.auth.presentation.support.CookieTokenExtractor;
 import com.blackcompany.eeos.auth.presentation.support.HeaderTokenExtractor;
 import com.blackcompany.eeos.auth.presentation.support.MemberArgumentResolver;
@@ -18,6 +19,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class LoginConfig implements WebMvcConfigurer {
 	private final MemberArgumentResolver memberArgumentResolver;
 	private final TokenResolver tokenResolver;
+	private final CookieNameFormatter cookieNameFormatter;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
@@ -48,7 +50,7 @@ public class LoginConfig implements WebMvcConfigurer {
 	@Bean
 	public AuthInterceptor reissueAuthInterceptor() {
 		return AuthInterceptor.builder()
-				.tokenExtractor(new CookieTokenExtractor())
+				.tokenExtractor(new CookieTokenExtractor(cookieNameFormatter))
 				.tokenResolver(tokenResolver)
 				.build();
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
@@ -2,7 +2,6 @@ package com.blackcompany.eeos.auth.presentation;
 
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.presentation.interceptor.AuthInterceptor;
-import com.blackcompany.eeos.auth.presentation.support.CookieNameFormatter;
 import com.blackcompany.eeos.auth.presentation.support.CookieTokenExtractor;
 import com.blackcompany.eeos.auth.presentation.support.HeaderTokenExtractor;
 import com.blackcompany.eeos.auth.presentation.support.MemberArgumentResolver;
@@ -19,7 +18,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class LoginConfig implements WebMvcConfigurer {
 	private final MemberArgumentResolver memberArgumentResolver;
 	private final TokenResolver tokenResolver;
-	private final CookieNameFormatter cookieNameFormatter;
+	private final HeaderTokenExtractor headerTokenExtractor;
+	private final CookieTokenExtractor cookieTokenExtractor;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
@@ -42,7 +42,7 @@ public class LoginConfig implements WebMvcConfigurer {
 	@Bean
 	public AuthInterceptor memberAuthInterceptor() {
 		return AuthInterceptor.builder()
-				.tokenExtractor(new HeaderTokenExtractor())
+				.tokenExtractor(headerTokenExtractor)
 				.tokenResolver(tokenResolver)
 				.build();
 	}
@@ -50,7 +50,7 @@ public class LoginConfig implements WebMvcConfigurer {
 	@Bean
 	public AuthInterceptor reissueAuthInterceptor() {
 		return AuthInterceptor.builder()
-				.tokenExtractor(new CookieTokenExtractor(cookieNameFormatter))
+				.tokenExtractor(cookieTokenExtractor)
 				.tokenResolver(tokenResolver)
 				.build();
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
@@ -30,7 +30,7 @@ public class AuthCookieManager implements CookieManager {
 
 	@Override
 	public ResponseCookie setCookie(String key, String value) {
-		return ResponseCookie.from(profile.getProfile() + key, value)
+		return ResponseCookie.from(getCookieName(key), value)
 				.path(path)
 				.domain(domain)
 				.httpOnly(HTTP_ONLY)
@@ -42,7 +42,7 @@ public class AuthCookieManager implements CookieManager {
 
 	@Override
 	public ResponseCookie deleteCookie(String key) {
-		return ResponseCookie.from(profile.getProfile() + key, "")
+		return ResponseCookie.from(getCookieName(key), "")
 				.path(path)
 				.domain(domain)
 				.httpOnly(HTTP_ONLY)
@@ -50,5 +50,9 @@ public class AuthCookieManager implements CookieManager {
 				.sameSite(SAMESITE)
 				.maxAge(TimeUtil.convertSecondsFromMillis(EXPIRATION))
 				.build();
+	}
+
+	private String getCookieName(String key) {
+		return String.format("%s_%s", profile.getProfile(), key);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
@@ -1,7 +1,6 @@
 package com.blackcompany.eeos.auth.presentation.support;
 
 import com.blackcompany.eeos.common.presentation.support.CookieManager;
-import com.blackcompany.eeos.common.utils.ProfileUtil;
 import com.blackcompany.eeos.common.utils.TimeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,7 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AuthCookieManager implements CookieManager {
 
-	private final ProfileUtil profile;
+	private final CookieNameFormatter cookieNameFormatter;
 
 	private static final Boolean HTTP_ONLY = true;
 	private static final Boolean SECURE = true;
@@ -30,7 +29,7 @@ public class AuthCookieManager implements CookieManager {
 
 	@Override
 	public ResponseCookie setCookie(String key, String value) {
-		return ResponseCookie.from(getCookieName(key), value)
+		return ResponseCookie.from(cookieNameFormatter.format(key), value)
 				.path(path)
 				.domain(domain)
 				.httpOnly(HTTP_ONLY)
@@ -42,7 +41,7 @@ public class AuthCookieManager implements CookieManager {
 
 	@Override
 	public ResponseCookie deleteCookie(String key) {
-		return ResponseCookie.from(getCookieName(key), "")
+		return ResponseCookie.from(cookieNameFormatter.format(key), "")
 				.path(path)
 				.domain(domain)
 				.httpOnly(HTTP_ONLY)
@@ -50,9 +49,5 @@ public class AuthCookieManager implements CookieManager {
 				.sameSite(SAMESITE)
 				.maxAge(TimeUtil.convertSecondsFromMillis(EXPIRATION))
 				.build();
-	}
-
-	private String getCookieName(String key) {
-		return String.format("%s_%s", profile.getProfile(), key);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
@@ -1,13 +1,18 @@
 package com.blackcompany.eeos.auth.presentation.support;
 
 import com.blackcompany.eeos.common.presentation.support.CookieManager;
+import com.blackcompany.eeos.common.utils.ProfileUtil;
 import com.blackcompany.eeos.common.utils.TimeUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class AuthCookieManager implements CookieManager {
+
+	private final ProfileUtil profile;
 
 	private static final Boolean HTTP_ONLY = true;
 	private static final Boolean SECURE = true;
@@ -25,7 +30,7 @@ public class AuthCookieManager implements CookieManager {
 
 	@Override
 	public ResponseCookie setCookie(String key, String value) {
-		return ResponseCookie.from(key, value)
+		return ResponseCookie.from(profile.getProfile() + key, value)
 				.path(path)
 				.domain(domain)
 				.httpOnly(HTTP_ONLY)
@@ -37,7 +42,7 @@ public class AuthCookieManager implements CookieManager {
 
 	@Override
 	public ResponseCookie deleteCookie(String key) {
-		return ResponseCookie.from(key, "")
+		return ResponseCookie.from(profile.getProfile() + key, "")
 				.path(path)
 				.domain(domain)
 				.httpOnly(HTTP_ONLY)

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/CookieNameFormatter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/CookieNameFormatter.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.auth.presentation.support;
+
+import com.blackcompany.eeos.common.utils.ProfileUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieNameFormatter {
+	private final ProfileUtil profile;
+
+	public String format(String key) {
+		return String.format("%s_%s", profile.getProfile(), key);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/CookieTokenExtractor.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/CookieTokenExtractor.java
@@ -4,17 +4,20 @@ import com.blackcompany.eeos.auth.application.exception.NotFoundCookieException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Objects;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component("cookie")
+@RequiredArgsConstructor
 public class CookieTokenExtractor implements TokenExtractor {
+	private final CookieNameFormatter cookieNameFormatter;
 
 	@Override
 	public String extract(HttpServletRequest request) {
 		Cookie[] cookies = getCookies(request);
 
 		for (Cookie cookie : cookies) {
-			if (Objects.equals(AuthConstants.TOKEN_KEY, cookie.getName())) {
+			if (Objects.equals(cookieNameFormatter.format(AuthConstants.TOKEN_KEY), cookie.getName())) {
 				return getValue(cookie.getValue());
 			}
 		}

--- a/eeos/src/main/java/com/blackcompany/eeos/common/utils/ProfileUtil.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/common/utils/ProfileUtil.java
@@ -2,24 +2,17 @@ package com.blackcompany.eeos.common.utils;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class ProfileUtil {
-	private final Environment environment;
-	private final Set<String> activeProfiles = new CopyOnWriteArraySet<>();
+	private final Set<String> activeProfiles;
 
-	private Set<String> getActiveProfiles() {
-		if (activeProfiles.isEmpty()) {
-			activeProfiles.addAll(
-					Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet()));
-		}
-		return activeProfiles;
+	public ProfileUtil(Environment environment) {
+		this.activeProfiles =
+				Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet());
 	}
 
 	public String getProfile() {
@@ -27,25 +20,21 @@ public class ProfileUtil {
 			return "local";
 		} else if (isDev()) {
 			return "dev";
-		} else if (isLive()) {
+		} else if (isProd()) {
 			return "live";
 		}
-		return getFirstProfile();
+		return activeProfiles.stream().findFirst().orElse("unknown");
 	}
 
-	public boolean isLocal() {
-		return getActiveProfiles().contains("local");
+	private boolean isLocal() {
+		return activeProfiles.contains("local");
 	}
 
-	public boolean isDev() {
-		return getActiveProfiles().contains("dev");
+	private boolean isDev() {
+		return activeProfiles.contains("dev");
 	}
 
-	public boolean isLive() {
-		return getActiveProfiles().contains("live");
-	}
-
-	private String getFirstProfile() {
-		return Arrays.stream(environment.getActiveProfiles()).findFirst().orElse("unknown");
+	private boolean isProd() {
+		return activeProfiles.contains("prod");
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/common/utils/ProfileUtil.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/common/utils/ProfileUtil.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.common.utils;
 
 import java.util.Arrays;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
@@ -11,11 +12,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProfileUtil {
 	private final Environment environment;
-	private Set<String> activeProfiles;
+	private final Set<String> activeProfiles = new CopyOnWriteArraySet<>();
 
 	private Set<String> getActiveProfiles() {
-		if (activeProfiles == null) {
-			activeProfiles = Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet());
+		if (activeProfiles.isEmpty()) {
+			activeProfiles.addAll(
+					Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet()));
 		}
 		return activeProfiles;
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/common/utils/ProfileUtil.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/common/utils/ProfileUtil.java
@@ -1,0 +1,49 @@
+package com.blackcompany.eeos.common.utils;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileUtil {
+	private final Environment environment;
+	private Set<String> activeProfiles;
+
+	private Set<String> getActiveProfiles() {
+		if (activeProfiles == null) {
+			activeProfiles = Arrays.stream(environment.getActiveProfiles()).collect(Collectors.toSet());
+		}
+		return activeProfiles;
+	}
+
+	public String getProfile() {
+		if (isLocal()) {
+			return "local";
+		} else if (isDev()) {
+			return "dev";
+		} else if (isLive()) {
+			return "live";
+		}
+		return getFirstProfile();
+	}
+
+	public boolean isLocal() {
+		return getActiveProfiles().contains("local");
+	}
+
+	public boolean isDev() {
+		return getActiveProfiles().contains("dev");
+	}
+
+	public boolean isLive() {
+		return getActiveProfiles().contains("live");
+	}
+
+	private String getFirstProfile() {
+		return Arrays.stream(environment.getActiveProfiles()).findFirst().orElse("unknown");
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/support/CookieTokenExtractorTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/support/CookieTokenExtractorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.blackcompany.eeos.auth.application.exception.NotFoundCookieException;
+import com.blackcompany.eeos.common.utils.ProfileUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,12 +16,37 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CookieTokenExtractorTest {
-	@Mock HttpServletRequest request;
-	CookieTokenExtractor cookieTokenExtractor;
+
+	@Mock private HttpServletRequest request;
+
+	@Mock private ProfileUtil profileUtil;
+
+	private CookieTokenExtractor cookieTokenExtractor;
+	private CookieNameFormatter cookieNameFormatter;
 
 	@BeforeEach
 	void setUp() {
-		cookieTokenExtractor = new CookieTokenExtractor();
+		cookieNameFormatter = new CookieNameFormatter(profileUtil);
+		cookieTokenExtractor = new CookieTokenExtractor(cookieNameFormatter);
+	}
+
+	@Test
+	@DisplayName("토큰을 키로 가지고 있는 쿠키가 있을 때 쿠키의 값을 반환한다.")
+	void existing_token_cookie() {
+		// given
+		String value = "value";
+		String cookieName = cookieNameFormatter.format(AuthConstants.TOKEN_KEY);
+
+		Cookie[] cookies = new Cookie[1];
+		Cookie cookie = new Cookie(cookieName, value);
+		cookies[0] = cookie;
+		when(request.getCookies()).thenReturn(cookies);
+
+		// when
+		String extract = cookieTokenExtractor.extract(request);
+
+		// then
+		assertEquals(value, extract);
 	}
 
 	@Test
@@ -38,32 +64,11 @@ class CookieTokenExtractorTest {
 	void not_found_token_cookie_exception() {
 		// given
 		Cookie[] cookies = new Cookie[1];
-		Cookie cookie = new Cookie("key", "value");
+		Cookie cookie = new Cookie("wrong_key", "value");
 		cookies[0] = cookie;
-
 		when(request.getCookies()).thenReturn(cookies);
 
 		// when & then
 		assertThrows(NotFoundCookieException.class, () -> cookieTokenExtractor.extract(request));
-	}
-
-	@Test
-	@DisplayName("토큰을 키로 가지고 있는 쿠키가 있을 때 쿠키의 값을 반환한다.")
-	void existing_token_cookie() {
-		// given
-		String key = "eeos_token";
-		String value = "value";
-
-		Cookie[] cookies = new Cookie[1];
-		Cookie cookie = new Cookie(key, value);
-		cookies[0] = cookie;
-
-		when(request.getCookies()).thenReturn(cookies);
-		System.out.println(request.getCookies().length);
-
-		String extract = cookieTokenExtractor.extract(request);
-
-		// then
-		assertEquals(value, extract);
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #202 

## ✒️ 작업 내용
* {환경명}_eeos_token : 쿠키 이름
    * ex) local_eeos_token
* 환경명은 profile로 가지고 옵니다.
* 쿠키에서 추출 및 쿠키 생성 시에 공통되게 설정할 수 있게 CookieNameFormat 클래스를 생성했습니다.

### 스크린샷 🏞️ (선택)
* 로그인 시 쿠키 발급(local)
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/15cd4ce6-67dd-44d6-99df-78997f90c34e" />

* 쿠키 재발급 시(local)
<img width="1303" alt="image" src="https://github.com/user-attachments/assets/34075123-9583-4489-9cdc-ab603d9a0f06" />

* 로그인 시 쿠키 발급(dev)
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/808a1a37-4c4f-47af-845b-68ee92890326" />


## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새 기능**
  - 환경 기반 프로필 관리와 연동되는 쿠키 네이밍 포맷터가 도입되었습니다.
  - 새로운 프로필 유틸리티 클래스가 추가되어 현재 프로필을 효율적으로 관리합니다.
- **리팩토링**
  - 인증 토큰 추출 및 쿠키 생성/삭제 로직이 개선되어 일관성과 안정성이 향상되었습니다.
- **테스트**
  - 토큰 추출 동작을 검증하는 테스트 케이스가 업데이트되어 신뢰성을 확보했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->