### PR TITLE
[FEAT] PR 작성자와 댓글단 사람 동일할 때, 봇일 때 알람 제거

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -1,7 +1,7 @@
 name: PR Slack Notification
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened,ready_for_review]
 permissions:
   pull-requests: read
 jobs:

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -8,87 +8,109 @@ jobs:
   notify_reviewers:
     runs-on: ubuntu-latest
     steps:
-    - name: Check required secrets
-      run: |
-        if [ -z "${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}" ]; then
-          echo "Error: SLACK_PR_CREATE_WEBHOOK_URL is not set"
-          exit 1
-        fi
-        if [ -z "${{ secrets.SLACK_IDS }}" ]; then
-          echo "Error: SLACK_IDS is not set"
-          exit 1
-        fi
-    - name: Set environment variables
-      run: |
-        echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}" >> $GITHUB_ENV
-        echo 'SLACK_IDS=${{ toJson(secrets.SLACK_IDS) }}' >> $GITHUB_ENV
-      shell: bash
-    - name: Send Slack notification for new PR
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        set -e
-        PR_TITLE="${{ github.event.pull_request.title }}"
-        PR_URL="${{ github.event.pull_request.html_url }}"
-        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-        REVIEWERS='${{ toJson(github.event.pull_request.requested_reviewers) }}'
-        
-        if [ "$REVIEWERS" == "null" ] || [ "$REVIEWERS" == "[]" ]; then
-          echo "No reviewers requested for this PR"
-          exit 0
-        fi
-        
-        # Parse SLACK_IDS as JSON
-        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
-        if [ "$SLACK_IDS_JSON" == "{}" ]; then
-          echo "Warning: SLACK_IDS is not a valid JSON. Attempting to parse as a string."
-          SLACK_IDS_JSON=$(echo "$SLACK_IDS" | sed 's/^"//; s/"$//' | jq -R 'split(",") | map(split(":")) | from_entries' 2>/dev/null || echo "{}")
+      - name: 필수 시크릿 체크
+        run: |
+          if [ -z "${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}" ]; then
+            echo "에러: SLACK_PR_CREATE_WEBHOOK_URL이 설정되지 않았습니다"
+            exit 1
+          fi
+          if [ -z "${{ secrets.SLACK_IDS }}" ]; then
+            echo "에러: SLACK_IDS가 설정되지 않았습니다"
+            exit 1
+          fi
+      - name: 환경 변수 설정
+        run: |
+          echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}" >> $GITHUB_ENV
+          echo 'SLACK_IDS=${{ toJson(secrets.SLACK_IDS) }}' >> $GITHUB_ENV
+        shell: bash
+      - name: 새로운 PR에 대한 Slack 알림 전송
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          REVIEWERS='${{ toJson(github.event.pull_request.requested_reviewers) }}'
+          
+          if [ "$REVIEWERS" == "null" ] || [ "$REVIEWERS" == "[]" ]; then
+            echo "이 PR에 요청된 리뷰어가 없습니다"
+            exit 0
+          fi
+          
+          # SLACK_IDS를 JSON으로 파싱
+          SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
           if [ "$SLACK_IDS_JSON" == "{}" ]; then
-            echo "Error: Failed to parse SLACK_IDS as JSON or string. Please check the format."
-            exit 1
+            echo "경고: SLACK_IDS가 유효한 JSON이 아닙니다. 문자열로 파싱을 시도합니다."
+            SLACK_IDS_JSON=$(echo "$SLACK_IDS" | sed 's/^"//; s/"$//' | jq -R 'split(",") | map(split(":")) | from_entries' 2>/dev/null || echo "{}")
+            if [ "$SLACK_IDS_JSON" == "{}" ]; then
+              echo "에러: SLACK_IDS를 JSON이나 문자열로 파싱하는데 실패했습니다. 형식을 확인해주세요."
+              exit 1
+            fi
           fi
-        fi
-        
-        get_slack_id() {
-          local github_username="$1"
-          echo "$SLACK_IDS_JSON" | jq -r --arg user "$github_username" '.[$user] // empty'
-        }
-        
-        reviewers=$(echo "$REVIEWERS" | jq -r '.[].login // empty')
-        mentions=""
-        
-        for reviewer in $reviewers; do
-          slack_id=$(get_slack_id "$reviewer")
           
-          if [ -n "$slack_id" ]; then
-            mentions="$mentions <@$slack_id>"
-          else
-            mentions="$mentions $reviewer"
-            echo "Warning: No Slack ID found for GitHub user $reviewer" >&2
-          fi
-        done
-        
-        author_slack_id=$(get_slack_id "$PR_AUTHOR")
-        if [ -n "$author_slack_id" ]; then
-          author_mention="<@$author_slack_id>"
-        else
-          author_mention="$PR_AUTHOR"
-          echo "Warning: No Slack ID found for PR author $PR_AUTHOR" >&2
-        fi
-        
-        if [ -n "$mentions" ]; then
-          message="$mentions 님, $author_mention 님이 새로운 PR을 생성하였습니다: <$PR_URL|$PR_TITLE>"
-          response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\"$message\"}" \
-            "$SLACK_WEBHOOK_URL")
+          get_slack_id() {
+            local github_username="$1"
+            echo "$SLACK_IDS_JSON" | jq -r --arg user "$github_username" '.[$user] // empty'
+          }
           
-          if [ "$response" = "200" ]; then
-            echo "Successfully sent Slack notification"
+          # PR 작성자의 Slack ID 가져오기
+          author_slack_id=$(get_slack_id "$PR_AUTHOR")
+          if [ -n "$author_slack_id" ]; then
+            author_mention="<@$author_slack_id>"
           else
-            echo "Error: Failed to send Slack notification. HTTP status code: $response" >&2
-            exit 1
+            author_mention="$PR_AUTHOR"
+            echo "경고: PR 작성자 $PR_AUTHOR의 Slack ID를 찾을 수 없습니다" >&2
           fi
-        else
-          echo "No reviewers to notify"
-        fi
+          
+          # 리뷰어 목록 확인
+          reviewers=$(echo "$REVIEWERS" | jq -r '.[].login // empty')
+          mentions=""
+          
+          # EEOS-BE가 리뷰어인지 확인
+          if echo "$reviewers" | grep -q "EEOS-BE"; then
+            echo "EEOS-BE가 리뷰어로 지정되었습니다. 모든 등록된 사용자에게 알림을 보냅니다."
+          
+            # SLACK_IDS에 등록된 모든 사용자에게 알림
+            registered_users=$(echo "$SLACK_IDS_JSON" | jq -r 'keys[]')
+            for user in $registered_users; do
+              # PR 작성자는 제외
+              if [ "$user" = "$PR_AUTHOR" ]; then
+                continue
+              fi
+          
+              user_slack_id=$(echo "$SLACK_IDS_JSON" | jq -r --arg user "$user" '.[$user] // empty')
+              if [ -n "$user_slack_id" ]; then
+                mentions="$mentions <@$user_slack_id>"
+              fi
+            done
+          else
+            # 일반적인 리뷰어 처리
+            for reviewer in $reviewers; do
+              slack_id=$(get_slack_id "$reviewer")
+          
+              if [ -n "$slack_id" ]; then
+                mentions="$mentions <@$slack_id>"
+              else
+                mentions="$mentions $reviewer"
+                echo "경고: GitHub 사용자 $reviewer의 Slack ID를 찾을 수 없습니다" >&2
+              fi
+            done
+          fi
+          
+          if [ -n "$mentions" ]; then
+            message="$mentions 님, $author_mention 님이 새로운 PR을 생성하였습니다: <$PR_URL|$PR_TITLE>"
+            response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
+              --data "{\"text\":\"$message\"}" \
+              "$SLACK_WEBHOOK_URL")
+          
+            if [ "$response" = "200" ]; then
+              echo "Slack 알림 전송 성공"
+            else
+              echo "에러: Slack 알림 전송 실패. HTTP 상태 코드: $response" >&2
+              exit 1
+            fi
+          else
+            echo "알림을 보낼 리뷰어가 없습니다"
+          fi

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -28,7 +28,7 @@ jobs:
           # 봇 계정 리스트
           BOT_USERS=("github-actions[bot]" "dependabot[bot]" "coderabbitai[bot]")
           
-          # 봇이 리뷰어인 경우 제외
+          # 1. 봇이 리뷰어인 경우 제외
           for bot in "${BOT_USERS[@]}"; do
             if [ "$REVIEWER" = "$bot" ]; then
               echo "알림 제외: 봇 계정의 리뷰"
@@ -36,7 +36,7 @@ jobs:
             fi
           done
           
-          # PR 작성자가 봇의 댓글에 직접 답글을 다는 경우만 제외
+          # 2. PR 작성자가 봇의 댓글에 직접 답글을 다는 경우만 제외
           for bot in "${BOT_USERS[@]}"; do
             if [ "$PARENT_COMMENT_AUTHOR" = "$bot" ] && [ "$REVIEWER" = "$PR_AUTHOR" ]; then
               echo "알림 제외: PR 작성자가 봇의 댓글에 직접 답글을 달았습니다"

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -2,6 +2,8 @@ name: PR Review Slack Notification
 on:
   pull_request_review:
     types: [submitted]
+  pull_request_review_requested:
+    types: [created]
 jobs:
   notify_pr_author:
     runs-on: ubuntu-latest
@@ -15,80 +17,86 @@ jobs:
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"
         PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-        REVIEW_STATE="${{ github.event.review.state }}"
-        REVIEWER="${{ github.event.review.user.login }}"
         
-        # 자신의 PR에 댓글을 단 경우 제외
-        if [ "$PR_AUTHOR" = "$REVIEWER" ]; then
-          echo "Skipping notification: PR author and reviewer are the same"
-          exit 0
-        fi
-        
-        # 봇 계정인 경우 제외 (봇 계정 이름을 배열로 정의)
-        BOT_USERS=("github-actions[bot]" "dependabot[bot]" "coderabbitai[bot]")
-        for bot in "${BOT_USERS[@]}"; do
-          if [ "$REVIEWER" = "$bot" ]; then
-            echo "Skipping notification: Review by bot account"
-            exit 0
-          fi
-        done
-        
-        # Parse SLACK_IDS as JSON
-        SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
-        if [ "$SLACK_IDS_JSON" == "{}" ]; then
-          echo "Warning: SLACK_IDS is not a valid JSON. Attempting to parse as a string."
-          SLACK_IDS_JSON=$(echo "$SLACK_IDS" | sed 's/^"//; s/"$//' | jq -R 'split(",") | map(split(":")) | from_entries' 2>/dev/null || echo "{}")
-          if [ "$SLACK_IDS_JSON" == "{}" ]; then
-            echo "Error: Failed to parse SLACK_IDS as JSON or string. Please check the format."
-            exit 1
-          fi
-        fi
-        
-        get_slack_id() {
-          local github_username="$1"
-          echo "$SLACK_IDS_JSON" | jq -r --arg user "$github_username" '.[$user] // empty'
-        }
-        
-        author_slack_id=$(get_slack_id "$PR_AUTHOR")
-        reviewer_slack_id=$(get_slack_id "$REVIEWER")
-        
-        if [ -n "$author_slack_id" ]; then
-          author_mention="<@$author_slack_id>"
-        else
-          author_mention="$PR_AUTHOR"
-          echo "Warning: No Slack ID found for PR author $PR_AUTHOR" >&2
-        fi
-        
-        if [ -n "$reviewer_slack_id" ]; then
-          reviewer_mention="<@$reviewer_slack_id>"
-        else
-          reviewer_mention="$REVIEWER"
-          echo "Warning: No Slack ID found for reviewer $REVIEWER" >&2
-        fi
-        
-        case "$REVIEW_STATE" in
-          "changes_requested")
-            message="$author_mention님, $reviewer_mention님이 PR에 변경을 요청했습니다: <$PR_URL|$PR_TITLE>"
-            ;;
-          "commented")
-            message="$author_mention님, $reviewer_mention님이 PR에 댓글을 달았습니다: <$PR_URL|$PR_TITLE>"
-            ;;
-          "approved")
-            message="$author_mention님, 축하합니다! $reviewer_mention님이 PR을 승인했습니다: <$PR_URL|$PR_TITLE>"
-            ;;
-        esac
-        
-        if [ -n "$message" ]; then
-          response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\"$message\"}" \
-            "$SLACK_WEBHOOK_URL")
+        if [ "${{ github.event_name }}" = "pull_request_review" ]; then
+          REVIEW_STATE="${{ github.event.review.state }}"
+          REVIEWER="${{ github.event.review.user.login }}"
           
-          if [ "$response" = "200" ]; then
-            echo "Successfully sent Slack notification"
-          else
-            echo "Error: Failed to send Slack notification. HTTP status code: $response" >&2
+          # 바로 직전 댓글의 작성자 확인
+          PARENT_COMMENT_AUTHOR="${{ github.event.review.in_reply_to_id && github.event.pull_request.comments[github.event.review.in_reply_to_id].user.login || '' }}"
+          
+          # 봇 계정 리스트
+          BOT_USERS=("github-actions[bot]" "dependabot[bot]" "coderabbitai[bot]")
+          
+          # 봇이 리뷰어인 경우 제외
+          for bot in "${BOT_USERS[@]}"; do
+            if [ "$REVIEWER" = "$bot" ]; then
+              echo "알림 제외: 봇 계정의 리뷰"
+              exit 0
+            fi
+          done
+          
+          # PR 작성자가 봇의 댓글에 직접 답글을 다는 경우만 제외
+          for bot in "${BOT_USERS[@]}"; do
+            if [ "$PARENT_COMMENT_AUTHOR" = "$bot" ] && [ "$REVIEWER" = "$PR_AUTHOR" ]; then
+              echo "알림 제외: PR 작성자가 봇의 댓글에 직접 답글을 달았습니다"
+              exit 0
+            fi
+          done
+          
+          # SLACK_IDS를 JSON으로 파싱
+          SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
+          if [ "$SLACK_IDS_JSON" == "{}" ]; then
+            echo "에러: SLACK_IDS가 올바른 JSON 형식이 아닙니다"
             exit 1
           fi
-        else
-          echo "No notification to send"
+          
+          get_slack_id() {
+            local github_username="$1"
+            echo "$SLACK_IDS_JSON" | jq -r --arg user "$github_username" '.[$user] // empty'
+          }
+          
+          author_slack_id=$(get_slack_id "$PR_AUTHOR")
+          reviewer_slack_id=$(get_slack_id "$REVIEWER")
+          
+          if [ -n "$author_slack_id" ]; then
+            author_mention="<@$author_slack_id>"
+          else
+            author_mention="$PR_AUTHOR"
+            echo "경고: PR 작성자 $PR_AUTHOR의 Slack ID를 찾을 수 없습니다" >&2
+          fi
+          
+          if [ -n "$reviewer_slack_id" ]; then
+            reviewer_mention="<@$reviewer_slack_id>"
+          else
+            reviewer_mention="$REVIEWER"
+            echo "경고: 리뷰어 $REVIEWER의 Slack ID를 찾을 수 없습니다" >&2
+          fi
+          
+          case "$REVIEW_STATE" in
+            "changes_requested")
+              message="$author_mention님, $reviewer_mention님이 PR에 변경을 요청했습니다: <$PR_URL|$PR_TITLE>"
+              ;;
+            "commented")
+              message="$author_mention님, $reviewer_mention님이 PR에 댓글을 달았습니다: <$PR_URL|$PR_TITLE>"
+              ;;
+            "approved")
+              message="$author_mention님, 축하합니다! $reviewer_mention님이 PR을 승인했습니다: <$PR_URL|$PR_TITLE>"
+              ;;
+          esac
+          
+          if [ -n "$message" ]; then
+            response=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'Content-type: application/json' \
+              --data "{\"text\":\"$message\"}" \
+              "$SLACK_WEBHOOK_URL")
+            
+            if [ "$response" = "200" ]; then
+              echo "Slack 알림 전송 성공"
+            else
+              echo "에러: Slack 알림 전송 실패. HTTP 상태 코드: $response" >&2
+              exit 1
+            fi
+          else
+            echo "전송할 알림 없음"
+          fi
         fi

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -2,8 +2,8 @@ name: PR Review Slack Notification
 on:
   pull_request_review:
     types: [submitted]
-  pull_request_review_requested:
-    types: [created]
+  pull_request:
+    types: [review_requested]
 jobs:
   notify_pr_author:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-review-notification.yml
+++ b/.github/workflows/pr-review-notification.yml
@@ -18,6 +18,21 @@ jobs:
         REVIEW_STATE="${{ github.event.review.state }}"
         REVIEWER="${{ github.event.review.user.login }}"
         
+        # 자신의 PR에 댓글을 단 경우 제외
+        if [ "$PR_AUTHOR" = "$REVIEWER" ]; then
+          echo "Skipping notification: PR author and reviewer are the same"
+          exit 0
+        fi
+        
+        # 봇 계정인 경우 제외 (봇 계정 이름을 배열로 정의)
+        BOT_USERS=("github-actions[bot]" "dependabot[bot]" "coderabbitai[bot]")
+        for bot in "${BOT_USERS[@]}"; do
+          if [ "$REVIEWER" = "$bot" ]; then
+            echo "Skipping notification: Review by bot account"
+            exit 0
+          fi
+        done
+        
         # Parse SLACK_IDS as JSON
         SLACK_IDS_JSON=$(echo "$SLACK_IDS" | jq -r '.' 2>/dev/null || echo "{}")
         if [ "$SLACK_IDS_JSON" == "{}" ]; then


### PR DESCRIPTION
## 📌 관련 이슈
closed #204 

## ✒️ 작업 내용
* PR 작성자와 댓글 작성자가 동일할 때 알람 x
* 댓글 작성자가 bot일 때 알람 x
* EEOS-BE 리뷰어로 선정 시 알람 제공 o

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 리뷰 요청 시, PR 작성자를 제외한 관련 팀원들에게 개별 알림을 전송하도록 알림 로직을 개선했습니다.
	- 주요 리뷰어에 대한 특별 처리 및 봇 계정 제외 기능이 도입되어 알림 대상이 더욱 명확해졌습니다.
	- 새로운 이벤트 타입인 `ready_for_review`가 추가되어 PR 상태에 따른 알림 조건이 확장되었습니다.
	- 오류 발생 시 한국어 오류 메시지가 제공되어 문제 파악이 용이해졌습니다.
- **문서화**
	- 알림 워크플로우의 모든 메시지 및 주석을 한국어로 번역하여 사용자 친화성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->