### PR TITLE
[FEAT] RequestScope 구현

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
@@ -32,8 +32,7 @@ public class LoginConfig implements WebMvcConfigurer {
 						"/api/guest/**", "/api/auth/**", "/api/health-check", "/api/programs/**");
 		registry
 				.addInterceptor(reissueAuthInterceptor())
-				.addPathPatterns("/auth/reissue")
-				.excludePathPatterns("/api/guest/**", "/api/auth/**", "/api/health-check");
+				.addPathPatterns("/api/auth/reissue");
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/LoginConfig.java
@@ -30,9 +30,7 @@ public class LoginConfig implements WebMvcConfigurer {
 				.addPathPatterns("/api/**")
 				.excludePathPatterns(
 						"/api/guest/**", "/api/auth/**", "/api/health-check", "/api/programs/**");
-		registry
-				.addInterceptor(reissueAuthInterceptor())
-				.addPathPatterns("/api/auth/reissue");
+		registry.addInterceptor(reissueAuthInterceptor()).addPathPatterns("/api/auth/reissue");
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/interceptor/AuthInterceptor.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/interceptor/AuthInterceptor.java
@@ -38,7 +38,8 @@ public class AuthInterceptor implements HandlerInterceptor {
 	}
 
 	@Override
-	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+	public void afterCompletion(
+			HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
 			throws Exception {
 		RequestScope.clear();
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/interceptor/AuthInterceptor.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/interceptor/AuthInterceptor.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.auth.presentation.interceptor;
 
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.presentation.support.TokenExtractor;
+import com.blackcompany.eeos.common.utils.RequestScope;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -30,8 +31,16 @@ public class AuthInterceptor implements HandlerInterceptor {
 		}
 
 		String token = tokenExtractor.extract(request);
-		tokenResolver.getUserDataByAccessToken(token);
+		Long memberId = tokenResolver.getUserDataByAccessToken(token);
+		RequestScope.setMemberId(memberId);
+
 		return true;
+	}
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+			throws Exception {
+		RequestScope.clear();
 	}
 
 	public static class AuthInterceptorBuilder {

--- a/eeos/src/main/java/com/blackcompany/eeos/common/utils/RequestScope.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/common/utils/RequestScope.java
@@ -1,0 +1,21 @@
+package com.blackcompany.eeos.common.utils;
+
+
+// HTTP Request 를 보낸 사용자의 정보를 저장하는 클래스
+public class RequestScope {
+
+    public static final ThreadLocal<Long> requesterInfo = new ThreadLocal<>();
+
+    public static Long getMemberId() {
+        return requesterInfo.get();
+    }
+
+    public static void setMemberId(Long memberId) {
+        requesterInfo.set(memberId);
+    }
+
+    public static void clear() {
+        requesterInfo.remove();
+    }
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/common/utils/RequestScope.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/common/utils/RequestScope.java
@@ -1,21 +1,19 @@
 package com.blackcompany.eeos.common.utils;
 
-
 // HTTP Request 를 보낸 사용자의 정보를 저장하는 클래스
 public class RequestScope {
 
-    public static final ThreadLocal<Long> requesterInfo = new ThreadLocal<>();
+	public static final ThreadLocal<Long> requesterInfo = new ThreadLocal<>();
 
-    public static Long getMemberId() {
-        return requesterInfo.get();
-    }
+	public static Long getMemberId() {
+		return requesterInfo.get();
+	}
 
-    public static void setMemberId(Long memberId) {
-        requesterInfo.set(memberId);
-    }
+	public static void setMemberId(Long memberId) {
+		requesterInfo.set(memberId);
+	}
 
-    public static void clear() {
-        requesterInfo.remove();
-    }
-
+	public static void clear() {
+		requesterInfo.remove();
+	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
@@ -40,4 +40,12 @@ public class RequestScopeTest {
         Assertions.assertNull(RequestScope.getMemberId());
     }
 
+    @Test
+    @DisplayName("저장한_값을_삭제하면_null이_반환된다")
+    public void clearValue(){
+        RequestScope.setMemberId(1L);
+        RequestScope.clear();
+        Assertions.assertNull(RequestScope.getMemberId());
+    }
+
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
@@ -29,6 +29,9 @@ public class RequestScopeTest {
 						() -> {
 							Assertions.assertNotEquals(1L, RequestScope.getMemberId());
 						});
+
+        setter.start();
+        getter.start();
 	}
 
 	@Test

--- a/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
@@ -1,0 +1,43 @@
+package com.blackcompany.eeos.common.util;
+
+import com.blackcompany.eeos.common.utils.RequestScope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class RequestScopeTest {
+
+    @Test
+    @DisplayName("저장한_값을_꺼낼_수_있다")
+    public void requestScope() {
+        RequestScope.setMemberId(1L);
+        Assertions.assertEquals(1L, RequestScope.getMemberId());
+    }
+
+    @Test
+    @DisplayName("서로_다른_스레드에서_저장한_값은_접근할_수_없다")
+    public void clear() {
+        Thread setter = new Thread(() -> {
+            RequestScope.setMemberId(1L);
+            Assertions.assertEquals(1L, RequestScope.getMemberId());
+        });
+
+        Thread getter = new Thread(()->{
+            Assertions.assertNotEquals(1L, RequestScope.getMemberId());
+        });
+    }
+
+    @Test
+    @DisplayName("null을_저장하면_null이_반환된다")
+    public void nullValue1(){
+        RequestScope.setMemberId(null);
+        Assertions.assertNull(RequestScope.getMemberId());
+    }
+
+    @Test
+    @DisplayName("아무것도_저장하지_않으면_null이_반환된다")
+    public void nullValue2(){
+        Assertions.assertNull(RequestScope.getMemberId());
+    }
+
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
@@ -30,8 +30,8 @@ public class RequestScopeTest {
 							Assertions.assertNotEquals(1L, RequestScope.getMemberId());
 						});
 
-        setter.start();
-        getter.start();
+		setter.start();
+		getter.start();
 	}
 
 	@Test

--- a/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/common/util/RequestScopeTest.java
@@ -7,45 +7,48 @@ import org.junit.jupiter.api.Test;
 
 public class RequestScopeTest {
 
-    @Test
-    @DisplayName("저장한_값을_꺼낼_수_있다")
-    public void requestScope() {
-        RequestScope.setMemberId(1L);
-        Assertions.assertEquals(1L, RequestScope.getMemberId());
-    }
+	@Test
+	@DisplayName("저장한_값을_꺼낼_수_있다")
+	public void requestScope() {
+		RequestScope.setMemberId(1L);
+		Assertions.assertEquals(1L, RequestScope.getMemberId());
+	}
 
-    @Test
-    @DisplayName("서로_다른_스레드에서_저장한_값은_접근할_수_없다")
-    public void clear() {
-        Thread setter = new Thread(() -> {
-            RequestScope.setMemberId(1L);
-            Assertions.assertEquals(1L, RequestScope.getMemberId());
-        });
+	@Test
+	@DisplayName("서로_다른_스레드에서_저장한_값은_접근할_수_없다")
+	public void clear() {
+		Thread setter =
+				new Thread(
+						() -> {
+							RequestScope.setMemberId(1L);
+							Assertions.assertEquals(1L, RequestScope.getMemberId());
+						});
 
-        Thread getter = new Thread(()->{
-            Assertions.assertNotEquals(1L, RequestScope.getMemberId());
-        });
-    }
+		Thread getter =
+				new Thread(
+						() -> {
+							Assertions.assertNotEquals(1L, RequestScope.getMemberId());
+						});
+	}
 
-    @Test
-    @DisplayName("null을_저장하면_null이_반환된다")
-    public void nullValue1(){
-        RequestScope.setMemberId(null);
-        Assertions.assertNull(RequestScope.getMemberId());
-    }
+	@Test
+	@DisplayName("null을_저장하면_null이_반환된다")
+	public void nullValue1() {
+		RequestScope.setMemberId(null);
+		Assertions.assertNull(RequestScope.getMemberId());
+	}
 
-    @Test
-    @DisplayName("아무것도_저장하지_않으면_null이_반환된다")
-    public void nullValue2(){
-        Assertions.assertNull(RequestScope.getMemberId());
-    }
+	@Test
+	@DisplayName("아무것도_저장하지_않으면_null이_반환된다")
+	public void nullValue2() {
+		Assertions.assertNull(RequestScope.getMemberId());
+	}
 
-    @Test
-    @DisplayName("저장한_값을_삭제하면_null이_반환된다")
-    public void clearValue(){
-        RequestScope.setMemberId(1L);
-        RequestScope.clear();
-        Assertions.assertNull(RequestScope.getMemberId());
-    }
-
+	@Test
+	@DisplayName("저장한_값을_삭제하면_null이_반환된다")
+	public void clearValue() {
+		RequestScope.setMemberId(1L);
+		RequestScope.clear();
+		Assertions.assertNull(RequestScope.getMemberId());
+	}
 }


### PR DESCRIPTION
## 📌 관련 이슈
closes #212 

## ✒️ 작업 내용
- RequestScope 구현
- AuthInterceptor 에 설정 추가
  - AuthInterceptor 가 토큰이 있는지 없는지 검사할 때, memberId 값 세팅

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 
- RequestScope를 static 멤버로 구현하여, 서비스 계층에서 별도의 빈 주입 없이 사용할 수 있도록 하였습니다.
- memberId를 할당하는 작업은, AuthInterceptor 에서 담당하고 있고,
  API 응답 이후, memberId 를 무조건 삭제하도록 처리했습니다.
- RequestScope 코드가 생각보다 간단한데, 설계나 기능적인 측면에서 제가 생각하지 못한 부분이 있다면 피드백 부탁드리겠습니다.

```java
public class Service {
    public void example(){
        Long memberId = RequestScope.getMemberId();
    }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 갱신 API 경로가 업데이트되어 인증 요청 처리가 개선되었습니다.
  - 사용자 관련 요청 데이터가 관리되고, 처리 완료 후 자동으로 초기화되어 보안성이 향상되었습니다.
  - 사용자 요청 정보를 저장하고 관리하는 새로운 유틸리티 클래스가 추가되었습니다.

- **테스트**
  - 요청 데이터 관리를 검증하는 새로운 테스트 케이스가 추가되어 기능의 안정성이 보장됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->