### PR TITLE
[FEAT] 나의 벌점 순위가 특정 순위 내에 들었는지 조회하는 API 구현

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.program.application.dto.request;
+
+import com.blackcompany.eeos.common.support.dto.AbstractApplicationDto;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CalendarApplicationCommand implements AbstractApplicationDto {
+	private Timestamp startDate;
+	private Timestamp endDate;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
@@ -1,15 +1,10 @@
 package com.blackcompany.eeos.program.application.dto.request;
 
 import com.blackcompany.eeos.common.support.dto.AbstractApplicationDto;
+import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class CalendarApplicationCommand implements AbstractApplicationDto {
-	private Timestamp startDate;
-	private Timestamp endDate;
-}
+public record CalendarApplicationCommand(
+		@NotNull(message = "시작 날짜는 필수입니다") Timestamp startDate,
+		@NotNull(message = "종료 날짜는 필수입니다") Timestamp endDate)
+		implements AbstractApplicationDto {}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/response/CalendarPeriodApplicationQuery.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/response/CalendarPeriodApplicationQuery.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.program.application.dto.response;
+
+import com.blackcompany.eeos.common.support.dto.AbstractApplicationDto;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CalendarPeriodApplicationQuery implements AbstractApplicationDto {
+	private Timestamp startDate;
+	private Timestamp endDate;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
@@ -35,9 +35,4 @@ public class CalendarModel {
 			endDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.AUGUST, 31).atTime(23, 59, 59));
 		}
 	}
-
-	public void change(Timestamp startDate, Timestamp endDate) {
-		this.startDate = startDate;
-		this.endDate = endDate;
-	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
@@ -1,0 +1,43 @@
+package com.blackcompany.eeos.program.application.model;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Slf4j
+public class CalendarModel {
+	private Timestamp startDate;
+	private Timestamp endDate;
+
+	public CalendarModel() {
+		LocalDate now = LocalDate.now();
+
+		// 9월 이후이면 9월 1일부터 다음 해 2월 말까지
+		if (now.getMonthValue() >= Month.SEPTEMBER.getValue()) {
+			startDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.SEPTEMBER, 1).atStartOfDay());
+			endDate =
+					Timestamp.valueOf(
+							LocalDate.of(
+											now.getYear() + 1,
+											Month.FEBRUARY,
+											Month.FEBRUARY.length(Year.isLeap(now.getYear() + 1)))
+									.atTime(23, 59, 59));
+		} else {
+			// 3월 이후이면 3월 1일부터 8월 말까지
+			startDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.MARCH, 1).atStartOfDay());
+			endDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.AUGUST, 31).atTime(23, 59, 59));
+		}
+	}
+
+	public void change(Timestamp startDate, Timestamp endDate) {
+		this.startDate = startDate;
+		this.endDate = endDate;
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/repository/CalendarRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/repository/CalendarRepository.java
@@ -1,0 +1,10 @@
+package com.blackcompany.eeos.program.application.repository;
+
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import java.util.Optional;
+
+public interface CalendarRepository {
+	Optional<CalendarModel> getCalendar();
+
+	CalendarModel updateCalendar(CalendarModel model);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
@@ -29,7 +29,7 @@ public class CalendarService implements GetCalendarUsecase, UpdateCalendarUsecas
 	public CalendarPeriodApplicationQuery updateCalendar(CalendarApplicationCommand command) {
 		CalendarModel model =
 				calendarRepository.updateCalendar(
-						new CalendarModel(command.getStartDate(), command.getEndDate()));
+						new CalendarModel(command.startDate(), command.endDate()));
 		return new CalendarPeriodApplicationQuery(model.getStartDate(), model.getEndDate());
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
@@ -1,0 +1,35 @@
+package com.blackcompany.eeos.program.application.service;
+
+import com.blackcompany.eeos.program.application.dto.request.CalendarApplicationCommand;
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import com.blackcompany.eeos.program.application.repository.CalendarRepository;
+import com.blackcompany.eeos.program.application.support.CalendarProvider;
+import com.blackcompany.eeos.program.application.usecase.GetCalendarUsecase;
+import com.blackcompany.eeos.program.application.usecase.UpdateCalendarUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarService implements GetCalendarUsecase, UpdateCalendarUsecase {
+	private final CalendarRepository calendarRepository;
+	private final CalendarProvider calendarProvider;
+
+	@Override
+	public CalendarPeriodApplicationQuery getCalendar() {
+		CalendarModel model = calendarProvider.getCalendar();
+		return new CalendarPeriodApplicationQuery(model.getStartDate(), model.getEndDate());
+	}
+
+	@Override
+	@Transactional
+	public CalendarPeriodApplicationQuery updateCalendar(CalendarApplicationCommand command) {
+		CalendarModel model =
+				calendarRepository.updateCalendar(
+						new CalendarModel(command.getStartDate(), command.getEndDate()));
+		return new CalendarPeriodApplicationQuery(model.getStartDate(), model.getEndDate());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/support/CalendarProvider.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/support/CalendarProvider.java
@@ -1,0 +1,16 @@
+package com.blackcompany.eeos.program.application.support;
+
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import com.blackcompany.eeos.program.application.repository.CalendarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarProvider {
+	private final CalendarRepository calendarRepository;
+
+	public CalendarModel getCalendar() {
+		return calendarRepository.getCalendar().orElse(new CalendarModel());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/GetCalendarUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/GetCalendarUsecase.java
@@ -1,0 +1,7 @@
+package com.blackcompany.eeos.program.application.usecase;
+
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+
+public interface GetCalendarUsecase {
+	CalendarPeriodApplicationQuery getCalendar();
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/UpdateCalendarUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/UpdateCalendarUsecase.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.program.application.usecase;
+
+import com.blackcompany.eeos.program.application.dto.request.CalendarApplicationCommand;
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+
+public interface UpdateCalendarUsecase {
+	CalendarPeriodApplicationQuery updateCalendar(CalendarApplicationCommand command);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarEntity.java
@@ -1,0 +1,39 @@
+package com.blackcompany.eeos.program.persistence;
+
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import jakarta.persistence.*;
+import java.sql.Timestamp;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(
+		name = CalendarEntity.ENTITY_PREFIX,
+		indexes = {
+			@Index(
+					name = "idx_calendar_created_date_id",
+					columnList = "createdDate DESC, calendar_id DESC")
+		})
+@SQLDelete(sql = "UPDATE calendar SET is_deleted=true where calendar_id=?")
+@Where(clause = "is_deleted=false")
+public class CalendarEntity extends BaseEntity {
+	public static final String ENTITY_PREFIX = "calendar";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(name = ENTITY_PREFIX + "_start_date", nullable = false)
+	private Timestamp startDate;
+
+	@Column(name = ENTITY_PREFIX + "_end_date", nullable = false)
+	private Timestamp endDate;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.blackcompany.eeos.program.persistence;
+
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import com.blackcompany.eeos.program.application.repository.CalendarRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CalendarRepositoryImpl implements CalendarRepository {
+	private final JpaCalendarRepository jpaCalendarRepository;
+
+	@Override
+	public Optional<CalendarModel> getCalendar() {
+		return jpaCalendarRepository.findTopByOrderByCreatedDateDesc().map(this::toModel);
+	}
+
+	@Override
+	public CalendarModel updateCalendar(CalendarModel model) {
+		CalendarEntity entity = toEntity(model);
+		CalendarEntity savedEntity = jpaCalendarRepository.save(entity);
+		return toModel(savedEntity);
+	}
+
+	private CalendarModel toModel(CalendarEntity entity) {
+		return CalendarModel.builder()
+				.startDate(entity.getStartDate())
+				.endDate(entity.getEndDate())
+				.build();
+	}
+
+	private CalendarEntity toEntity(CalendarModel model) {
+		return CalendarEntity.builder()
+				.startDate(model.getStartDate())
+				.endDate(model.getEndDate())
+				.build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/persistence/JpaCalendarRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/persistence/JpaCalendarRepository.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.program.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCalendarRepository extends JpaRepository<CalendarEntity, Long> {
+	Optional<CalendarEntity> findTopByOrderByCreatedDateDesc();
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/controller/CalendarController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/controller/CalendarController.java
@@ -1,0 +1,38 @@
+package com.blackcompany.eeos.program.presentation.controller;
+
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.response.MessageCode;
+import com.blackcompany.eeos.program.application.dto.request.CalendarApplicationCommand;
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+import com.blackcompany.eeos.program.application.usecase.GetCalendarUsecase;
+import com.blackcompany.eeos.program.application.usecase.UpdateCalendarUsecase;
+import com.blackcompany.eeos.program.presentation.dto.UpdateCalendarRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CalendarController {
+	private final GetCalendarUsecase getCalendarUsecase;
+	private final UpdateCalendarUsecase updateCalendarUsecase;
+
+	@PutMapping("/admin/calendars") // TODO : 인터셉터 단에서 어드민 검증
+	public ApiResponse<ApiResponseBody.SuccessBody<CalendarPeriodApplicationQuery>> updateCalendar(
+			@RequestBody @Valid UpdateCalendarRequest request) {
+		CalendarPeriodApplicationQuery response =
+				updateCalendarUsecase.updateCalendar(
+						new CalendarApplicationCommand(request.startDate(), request.endDate()));
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
+	}
+
+	@GetMapping("/calendars")
+	public ApiResponse<ApiResponseBody.SuccessBody<CalendarPeriodApplicationQuery>> getCalendar() {
+		CalendarPeriodApplicationQuery response = getCalendarUsecase.getCalendar();
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.program.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.sql.Timestamp;
+
+public record UpdateCalendarRequest(
+		@NotNull(message = "시작일은 필수값입니다.") Timestamp startDate,
+		@NotNull(message = "종료일은 필수값입니다.") Timestamp endDate) {}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
@@ -1,8 +1,15 @@
 package com.blackcompany.eeos.program.presentation.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 
 public record UpdateCalendarRequest(
 		@NotNull(message = "시작일은 필수값입니다.") Timestamp startDate,
-		@NotNull(message = "종료일은 필수값입니다.") Timestamp endDate) {}
+		@NotNull(message = "종료일은 필수값입니다.") Timestamp endDate) {
+
+	@AssertTrue(message = "종료일은 시작일 이후여야 합니다.")
+	public boolean isEndDateAfterStartDate() {
+		return endDate.getTime() > startDate.getTime();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/dto/AttendPenaltyRankingResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/dto/AttendPenaltyRankingResponse.java
@@ -1,0 +1,11 @@
+package com.blackcompany.eeos.target.application.dto;
+
+import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
+
+public record AttendPenaltyRankingResponse(boolean isRanked, int ranking)
+		implements AbstractResponseDto {
+
+	public static AttendPenaltyRankingResponse empty() {
+		return new AttendPenaltyRankingResponse(false, 0);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/dto/PenaltyInfoRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/dto/PenaltyInfoRequest.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.target.application.dto;
 
 import com.blackcompany.eeos.common.exception.InvalidParameterException;
 import com.blackcompany.eeos.common.support.dto.AbstractRequestDto;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -10,17 +11,23 @@ import org.springframework.web.bind.annotation.RequestParam;
 public record PenaltyInfoRequest(
 		@Positive(message = "page 값은 양수입니다.") int page,
 		@PositiveOrZero(message = "size 값은 음수가 될 수 없습니다.") int size,
-		@NotBlank(message = "sortType은 공백 문자열이 될 수 없습니다.") String sortType)
+		@NotBlank(message = "sortType은 공백 문자열이 될 수 없습니다.") String sortType,
+		@Nullable Long startDate,
+		@Nullable Long endDate)
 		implements AbstractRequestDto {
 
 	public PenaltyInfoRequest(
 			@RequestParam("page") int page,
 			@RequestParam("size") int size,
-			@RequestParam("sortType") String sortType) {
+			@RequestParam("sortType") String sortType,
+			@RequestParam(value = "startDate", required = false) Long startDate,
+			@RequestParam(value = "endDate", required = false) Long endDate) {
 		validateParameter(page, size, sortType);
 		this.page = page;
 		this.size = size;
 		this.sortType = sortType;
+		this.startDate = startDate;
+		this.endDate = endDate;
 	}
 
 	private void validateParameter(int page, int size, String sortType) {

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -12,6 +12,7 @@ import com.blackcompany.eeos.program.application.model.ProgramAttendMode;
 import com.blackcompany.eeos.program.application.model.ProgramModel;
 import com.blackcompany.eeos.program.application.model.converter.ProgramEntityConverter;
 import com.blackcompany.eeos.program.application.service.ProgramDateRangeService;
+import com.blackcompany.eeos.program.application.support.CalendarProvider;
 import com.blackcompany.eeos.program.persistence.ProgramRepository;
 import com.blackcompany.eeos.target.application.dto.AttendInfoActiveStatusResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoResponse;
@@ -43,6 +44,7 @@ import com.blackcompany.eeos.target.application.usecase.GetAttendStatusUsecase;
 import com.blackcompany.eeos.target.application.usecase.GetAttendantInfoUsecase;
 import com.blackcompany.eeos.target.persistence.AttendEntity;
 import com.blackcompany.eeos.target.persistence.AttendRepository;
+import com.blackcompany.eeos.target.persistence.PenaltyPointRepository;
 import com.blackcompany.eeos.target.persistence.ProgramRankCounterEntity;
 import com.blackcompany.eeos.target.persistence.ProgramRankCounterRepository;
 import java.sql.Timestamp;
@@ -87,6 +89,8 @@ public class AttendService
 	private final AttendCountCalculate attendCountCalculate;
 	private final AttendPenaltyResponseConverter attendPenaltyResponseConverter;
 	private final ProgramRankCounterRepository programRankCounterRepository;
+	private final CalendarProvider calendarProvider;
+	private final PenaltyPointRepository penaltyPointRepository;
 
 	@Override
 	public List<AttendInfoResponse> findAttendInfo(final Long programId) {
@@ -124,7 +128,6 @@ public class AttendService
 		return currentRank;
 	}
 
-	@Transactional
 	private ProgramRankCounterEntity createNewCounter(Long programId) {
 		ProgramRankCounterEntity newCounter =
 				ProgramRankCounterEntity.builder()
@@ -273,12 +276,11 @@ public class AttendService
 
 		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(order));
 
-		// TODO: null일 경우 startDate 와 endDate 시간 설정하기
-		Timestamp startTimestamp = new Timestamp(startDate);
-		Timestamp endTimestamp = new Timestamp(endDate);
+		Timestamp startTimestamp = startDate==null ? calendarProvider.getCalendar().getStartDate() : new Timestamp(startDate);
+		Timestamp endTimestamp = endDate==null ? calendarProvider.getCalendar().getEndDate() : new Timestamp(endDate);
 
 		Page<Object[]> pages =
-				attendRepository.findByPenaltyPointSum(startTimestamp, endTimestamp, pageable);
+				penaltyPointRepository.findByPenaltyPointSum(startTimestamp, endTimestamp, pageable);
 
 		List<Long> topMemberIds = pages.stream().map(o -> (Long) o[0]).toList();
 
@@ -289,7 +291,7 @@ public class AttendService
 									Collectors.toMap(
 											id -> id,
 											id ->
-													attendRepository.findTotalPenaltyScoreByMemberId(
+													penaltyPointRepository.findTotalPenaltyScoreByMemberId(
 															startTimestamp, endTimestamp, id)));
 
 			List<MemberModel> members = memberRepository.findMembersByIdsInOrder(topMemberIds);
@@ -299,8 +301,9 @@ public class AttendService
 							.map(
 									member -> {
 										Long penaltyPoint = memberIdToPenaltyPoint.get(member.getId());
+										Long ranking = penaltyPointRepository.countByPenaltyPointGreaterThan(startTimestamp, endTimestamp, penaltyPoint);
 										return attendPenaltyResponseConverter.from(
-												member, penaltyPoint, Long.valueOf(members.indexOf(member) + 1));
+												member, penaltyPoint, ranking+1);
 									})
 							.toList();
 
@@ -316,29 +319,13 @@ public class AttendService
 
 		Long memberId = RequestScope.getMemberId();
 
-		Sort.Order order = Sort.Order.desc("totalScore");
+		Timestamp startDate = calendarProvider.getCalendar().getStartDate();
+		Timestamp endDate = calendarProvider.getCalendar().getEndDate();
 
-		Pageable pageable = PageRequest.of(0, rankOffset, Sort.by(order));
+		Long myPenaltyPoint = penaltyPointRepository.findTotalPenaltyScoreByMemberId(startDate, endDate, memberId);
+		long myPenaltyRank = penaltyPointRepository.countByPenaltyPointGreaterThan(startDate, endDate, myPenaltyPoint) + 1;
 
-		Page<Object[]> pages = attendRepository.findByPenaltyPointSum(pageable);
-
-		if (!pages.isEmpty()) {
-			Map<Long, Long> penaltyByMemberId =
-					pages.stream()
-							.collect(
-									Collectors.toMap(
-											o -> (Long) o[0], // memberId
-											o -> (Long) o[1] // penaltyPoint
-											));
-
-			Long myPenaltyPoint = penaltyByMemberId.get(memberId);
-			Long myPenaltyRank = pages.stream().filter(o -> (Long) o[1] > myPenaltyPoint).count() + 1;
-			boolean isRanked = myPenaltyRank < rankOffset;
-
-			return new AttendPenaltyRankingResponse(isRanked, myPenaltyRank.intValue());
-		}
-
-		return AttendPenaltyRankingResponse.empty();
+		return new AttendPenaltyRankingResponse(myPenaltyRank < rankOffset, (int) myPenaltyRank);
 	}
 
 	private List<AttendModel> findMyAttends(List<ProgramModel> programs) {

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -16,6 +16,7 @@ import com.blackcompany.eeos.program.persistence.ProgramRepository;
 import com.blackcompany.eeos.target.application.dto.AttendInfoActiveStatusResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoWithProgramResponse;
+import com.blackcompany.eeos.target.application.dto.AttendPenaltyRankingResponse;
 import com.blackcompany.eeos.target.application.dto.AttendPenaltyResponse;
 import com.blackcompany.eeos.target.application.dto.AttendSummaryInfoResponse;
 import com.blackcompany.eeos.target.application.dto.ChangeAttendStatusResponse;
@@ -43,9 +44,6 @@ import com.blackcompany.eeos.target.application.usecase.GetAttendantInfoUsecase;
 import com.blackcompany.eeos.target.persistence.AttendEntity;
 import com.blackcompany.eeos.target.persistence.AttendRepository;
 import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -236,7 +234,8 @@ public class AttendService
 	}
 
 	@Override
-	public PageResponse<AttendPenaltyResponse> getPenaltyInfos(int page, int size, String sortType) {
+	public PageResponse<AttendPenaltyResponse> getPenaltyInfos(
+			int page, int size, String sortType, Long startDate, Long endDate) {
 
 		Sort.Order order;
 
@@ -248,14 +247,12 @@ public class AttendService
 
 		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(order));
 
-		// TODO: startDate 와 endDate 시간 설정하기
-		Timestamp startDate =
-				Timestamp.valueOf(LocalDateTime.of(LocalDate.of(2024, 3, 1), LocalTime.of(0, 0)));
-		Timestamp endDate =
-				Timestamp.valueOf(LocalDateTime.of(LocalDate.of(2025, 8, 1), LocalTime.of(0, 0)));
-		Long limit = 10L;
+		// TODO: null일 경우 startDate 와 endDate 시간 설정하기
+		Timestamp startTimestamp = new Timestamp(startDate);
+		Timestamp endTimestamp = new Timestamp(endDate);
 
-		Page<Object[]> pages = attendRepository.findByPenaltyPointSum(startDate, endDate, pageable);
+		Page<Object[]> pages =
+				attendRepository.findByPenaltyPointSum(startTimestamp, endTimestamp, pageable);
 
 		List<Long> topMemberIds = pages.stream().map(o -> (Long) o[0]).toList();
 
@@ -267,7 +264,7 @@ public class AttendService
 											id -> id,
 											id ->
 													attendRepository.findTotalPenaltyScoreByMemberId(
-															startDate, endDate, id)));
+															startTimestamp, endTimestamp, id)));
 
 			List<MemberModel> members = memberRepository.findMembersByIdsInOrder(topMemberIds);
 
@@ -286,6 +283,36 @@ public class AttendService
 		}
 
 		return new PageResponse<>(Page.empty(PageRequest.of(page - 1, size)));
+	}
+
+	@Override
+	public AttendPenaltyRankingResponse getMyPenaltyRanking(int rankOffset) {
+
+		Long memberId = RequestScope.getMemberId();
+
+		Sort.Order order = Sort.Order.desc("totalScore");
+
+		Pageable pageable = PageRequest.of(0, rankOffset, Sort.by(order));
+
+		Page<Object[]> pages = attendRepository.findByPenaltyPointSum(pageable);
+
+		if (!pages.isEmpty()) {
+			Map<Long, Long> penaltyByMemberId =
+					pages.stream()
+							.collect(
+									Collectors.toMap(
+											o -> (Long) o[0], // memberId
+											o -> (Long) o[1] // penaltyPoint
+											));
+
+			Long myPenaltyPoint = penaltyByMemberId.get(memberId);
+			Long myPenaltyRank = pages.stream().filter(o -> (Long) o[1] > myPenaltyPoint).count() + 1;
+			boolean isRanked = myPenaltyRank < rankOffset;
+
+			return new AttendPenaltyRankingResponse(isRanked, myPenaltyRank.intValue());
+		}
+
+		return AttendPenaltyRankingResponse.empty();
 	}
 
 	private List<AttendModel> findMyAttends(List<ProgramModel> programs) {

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -276,8 +276,12 @@ public class AttendService
 
 		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(order));
 
-		Timestamp startTimestamp = startDate==null ? calendarProvider.getCalendar().getStartDate() : new Timestamp(startDate);
-		Timestamp endTimestamp = endDate==null ? calendarProvider.getCalendar().getEndDate() : new Timestamp(endDate);
+		Timestamp startTimestamp =
+				startDate == null
+						? calendarProvider.getCalendar().getStartDate()
+						: new Timestamp(startDate);
+		Timestamp endTimestamp =
+				endDate == null ? calendarProvider.getCalendar().getEndDate() : new Timestamp(endDate);
 
 		Page<Object[]> pages =
 				penaltyPointRepository.findByPenaltyPointSum(startTimestamp, endTimestamp, pageable);
@@ -301,9 +305,10 @@ public class AttendService
 							.map(
 									member -> {
 										Long penaltyPoint = memberIdToPenaltyPoint.get(member.getId());
-										Long ranking = penaltyPointRepository.countByPenaltyPointGreaterThan(startTimestamp, endTimestamp, penaltyPoint);
-										return attendPenaltyResponseConverter.from(
-												member, penaltyPoint, ranking+1);
+										Long ranking =
+												penaltyPointRepository.countByPenaltyPointGreaterThan(
+														startTimestamp, endTimestamp, penaltyPoint);
+										return attendPenaltyResponseConverter.from(member, penaltyPoint, ranking + 1);
 									})
 							.toList();
 
@@ -322,8 +327,11 @@ public class AttendService
 		Timestamp startDate = calendarProvider.getCalendar().getStartDate();
 		Timestamp endDate = calendarProvider.getCalendar().getEndDate();
 
-		Long myPenaltyPoint = penaltyPointRepository.findTotalPenaltyScoreByMemberId(startDate, endDate, memberId);
-		long myPenaltyRank = penaltyPointRepository.countByPenaltyPointGreaterThan(startDate, endDate, myPenaltyPoint) + 1;
+		Long myPenaltyPoint =
+				penaltyPointRepository.findTotalPenaltyScoreByMemberId(startDate, endDate, memberId);
+		long myPenaltyRank =
+				penaltyPointRepository.countByPenaltyPointGreaterThan(startDate, endDate, myPenaltyPoint)
+						+ 1;
 
 		return new AttendPenaltyRankingResponse(myPenaltyRank < rankOffset, (int) myPenaltyRank);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/usecase/GetAttendantInfoUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/usecase/GetAttendantInfoUsecase.java
@@ -3,6 +3,7 @@ package com.blackcompany.eeos.target.application.usecase;
 import com.blackcompany.eeos.common.presentation.response.PageResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoWithProgramResponse;
+import com.blackcompany.eeos.target.application.dto.AttendPenaltyRankingResponse;
 import com.blackcompany.eeos.target.application.dto.AttendPenaltyResponse;
 import com.blackcompany.eeos.target.application.dto.AttendSummaryInfoResponse;
 import com.blackcompany.eeos.target.application.dto.QueryAttendStatusResponse;
@@ -25,7 +26,10 @@ public interface GetAttendantInfoUsecase {
 	PageResponse<AttendInfoWithProgramResponse> findMyAttendInfo(
 			final int page, final int size, final long startDate, final long endDate);
 
-	PageResponse<AttendPenaltyResponse> getPenaltyInfos(int page, int size, String sortType);
+	PageResponse<AttendPenaltyResponse> getPenaltyInfos(
+			int page, int size, String sortType, Long startDate, Long endDate);
 
 	AttendSummaryInfoResponse getMyAttendSummary(Long startDate, Long endDate);
+
+	AttendPenaltyRankingResponse getMyPenaltyRanking(int rankOffset);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -66,6 +66,10 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 			Pageable pageable);
 
 	@Query(
+			"SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a GROUP BY a.memberId) AS temp")
+	Page<Object[]> findByPenaltyPointSum(Pageable pageable);
+
+	@Query(
 			"SELECT SUM(a.penaltyScore) FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate AND a.memberId=:memberId")
 	Long findTotalPenaltyScoreByMemberId(
 			@Param("startDate") Timestamp startDate,

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -2,11 +2,8 @@ package com.blackcompany.eeos.target.persistence;
 
 import com.blackcompany.eeos.target.application.model.AttendStatus;
 import jakarta.persistence.LockModeType;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -57,5 +54,4 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 			"SELECT a FROM AttendEntity a WHERE a.programId IN :programIds AND a.memberId=:memberId AND a.isDeleted=false")
 	List<AttendEntity> findByProgramIdsAndMemberId(
 			@Param("programIds") List<Long> programIds, @Param("memberId") Long memberId);
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -58,21 +58,4 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 	List<AttendEntity> findByProgramIdsAndMemberId(
 			@Param("programIds") List<Long> programIds, @Param("memberId") Long memberId);
 
-	@Query(
-			"SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate  GROUP BY a.memberId) AS temp")
-	Page<Object[]> findByPenaltyPointSum(
-			@Param("startDate") Timestamp startDate,
-			@Param("endDate") Timestamp endDate,
-			Pageable pageable);
-
-	@Query(
-			"SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a GROUP BY a.memberId) AS temp")
-	Page<Object[]> findByPenaltyPointSum(Pageable pageable);
-
-	@Query(
-			"SELECT SUM(a.penaltyScore) FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate AND a.memberId=:memberId")
-	Long findTotalPenaltyScoreByMemberId(
-			@Param("startDate") Timestamp startDate,
-			@Param("endDate") Timestamp endDate,
-			@Param("memberId") Long memberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/PenaltyPointRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/PenaltyPointRepository.java
@@ -1,0 +1,39 @@
+package com.blackcompany.eeos.target.persistence;
+
+import java.sql.Timestamp;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PenaltyPointRepository extends JpaRepository<AttendEntity, Long> {
+
+    @Query(
+            "SELECT COUNT(*) FROM (SELECT a.memberId as memberId, a.penaltyScore as penaltyScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate) AS temp WHERE temp.penaltyScore = :penaltyPoint"
+    )
+    Long countByPenaltyPoint(@Param("startDate") Timestamp startDate, @Param("endDate") Timestamp endDate, @Param("penaltyPoint") Long penaltyPoint);
+
+    @Query(
+            "SELECT COUNT(*) FROM (SELECT a.memberId as memberId, a.penaltyScore as penaltyScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate) AS temp WHERE temp.penaltyScore > :penaltyPoint"
+    )
+    Long countByPenaltyPointGreaterThan(@Param("startDate") Timestamp startDate, @Param("endDate") Timestamp endDate, @Param("penaltyPoint") Long penaltyPoint);
+
+    @Query(
+            "SELECT SUM(a.penaltyScore) FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate AND a.memberId=:memberId")
+    Long findTotalPenaltyScoreByMemberId(
+            @Param("startDate") Timestamp startDate,
+            @Param("endDate") Timestamp endDate,
+            @Param("memberId") Long memberId);
+
+    @Query(
+            "SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate  GROUP BY a.memberId) AS temp")
+    Page<Object[]> findByPenaltyPointSum(
+            @Param("startDate") Timestamp startDate,
+            @Param("endDate") Timestamp endDate,
+            Pageable pageable);
+
+    @Query(
+            "SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a GROUP BY a.memberId) AS temp")
+    Page<Object[]> findByPenaltyPointSum(Pageable pageable);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/PenaltyPointRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/PenaltyPointRepository.java
@@ -9,31 +9,35 @@ import org.springframework.data.repository.query.Param;
 
 public interface PenaltyPointRepository extends JpaRepository<AttendEntity, Long> {
 
-    @Query(
-            "SELECT COUNT(*) FROM (SELECT a.memberId as memberId, a.penaltyScore as penaltyScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate) AS temp WHERE temp.penaltyScore = :penaltyPoint"
-    )
-    Long countByPenaltyPoint(@Param("startDate") Timestamp startDate, @Param("endDate") Timestamp endDate, @Param("penaltyPoint") Long penaltyPoint);
+	@Query(
+			"SELECT COUNT(*) FROM (SELECT a.memberId as memberId, a.penaltyScore as penaltyScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate) AS temp WHERE temp.penaltyScore = :penaltyPoint")
+	Long countByPenaltyPoint(
+			@Param("startDate") Timestamp startDate,
+			@Param("endDate") Timestamp endDate,
+			@Param("penaltyPoint") Long penaltyPoint);
 
-    @Query(
-            "SELECT COUNT(*) FROM (SELECT a.memberId as memberId, a.penaltyScore as penaltyScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate) AS temp WHERE temp.penaltyScore > :penaltyPoint"
-    )
-    Long countByPenaltyPointGreaterThan(@Param("startDate") Timestamp startDate, @Param("endDate") Timestamp endDate, @Param("penaltyPoint") Long penaltyPoint);
+	@Query(
+			"SELECT COUNT(*) FROM (SELECT a.memberId as memberId, a.penaltyScore as penaltyScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate) AS temp WHERE temp.penaltyScore > :penaltyPoint")
+	Long countByPenaltyPointGreaterThan(
+			@Param("startDate") Timestamp startDate,
+			@Param("endDate") Timestamp endDate,
+			@Param("penaltyPoint") Long penaltyPoint);
 
-    @Query(
-            "SELECT SUM(a.penaltyScore) FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate AND a.memberId=:memberId")
-    Long findTotalPenaltyScoreByMemberId(
-            @Param("startDate") Timestamp startDate,
-            @Param("endDate") Timestamp endDate,
-            @Param("memberId") Long memberId);
+	@Query(
+			"SELECT SUM(a.penaltyScore) FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate AND a.memberId=:memberId")
+	Long findTotalPenaltyScoreByMemberId(
+			@Param("startDate") Timestamp startDate,
+			@Param("endDate") Timestamp endDate,
+			@Param("memberId") Long memberId);
 
-    @Query(
-            "SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate  GROUP BY a.memberId) AS temp")
-    Page<Object[]> findByPenaltyPointSum(
-            @Param("startDate") Timestamp startDate,
-            @Param("endDate") Timestamp endDate,
-            Pageable pageable);
+	@Query(
+			"SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a WHERE a.createdDate >= :startDate AND a.createdDate <= :endDate  GROUP BY a.memberId) AS temp")
+	Page<Object[]> findByPenaltyPointSum(
+			@Param("startDate") Timestamp startDate,
+			@Param("endDate") Timestamp endDate,
+			Pageable pageable);
 
-    @Query(
-            "SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a GROUP BY a.memberId) AS temp")
-    Page<Object[]> findByPenaltyPointSum(Pageable pageable);
+	@Query(
+			"SELECT temp.memberId, temp.totalScore FROM (SELECT a.memberId as memberId, SUM(a.penaltyScore) as totalScore FROM AttendEntity a GROUP BY a.memberId) AS temp")
+	Page<Object[]> findByPenaltyPointSum(Pageable pageable);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
@@ -9,6 +9,7 @@ import com.blackcompany.eeos.common.presentation.response.PageResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoWithProgramResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfosSearchRequest;
+import com.blackcompany.eeos.target.application.dto.AttendPenaltyRankingResponse;
 import com.blackcompany.eeos.target.application.dto.AttendPenaltyResponse;
 import com.blackcompany.eeos.target.application.dto.AttendSummaryInfoResponse;
 import com.blackcompany.eeos.target.application.dto.ChangeAttendStatusResponse;
@@ -99,7 +100,7 @@ public class AttendController implements AttendApi {
 	@GetMapping("/attend/programs")
 	@Override
 	public ApiResponse<SuccessBody<PageResponse<AttendInfoWithProgramResponse>>>
-			getMyAttendInfosWithProgram(@Member Long memberId, @Valid AttendInfosSearchRequest request) {
+			getMyAttendInfosWithProgram(@Valid AttendInfosSearchRequest request) {
 		PageResponse<AttendInfoWithProgramResponse> responses =
 				getAttendantInfoUsecase.findMyAttendInfo(
 						request.getPage(), request.getSize(), request.getStartDate(), request.getEndDate());
@@ -111,7 +112,12 @@ public class AttendController implements AttendApi {
 	public ApiResponse<SuccessBody<PageResponse<AttendPenaltyResponse>>> getPenaltyInfo(
 			PenaltyInfoRequest request) {
 		PageResponse<AttendPenaltyResponse> responses =
-				getAttendantInfoUsecase.getPenaltyInfos(request.page(), request.size(), request.sortType());
+				getAttendantInfoUsecase.getPenaltyInfos(
+						request.page(),
+						request.size(),
+						request.sortType(),
+						request.startDate(),
+						request.endDate());
 
 		return ApiResponseGenerator.success(responses, HttpStatus.OK, MessageCode.GET);
 	}
@@ -122,6 +128,14 @@ public class AttendController implements AttendApi {
 			@RequestParam("startDate") Long startDate, @RequestParam("endDate") Long endDate) {
 		AttendSummaryInfoResponse response =
 				getAttendantInfoUsecase.getMyAttendSummary(startDate, endDate);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+	}
+
+	@Override
+	@GetMapping("/attend/penalty")
+	public ApiResponse<SuccessBody<AttendPenaltyRankingResponse>> getMyPenaltyRankingInfo(
+			@RequestParam("offset") int rankOffset) {
+		AttendPenaltyRankingResponse response = getAttendantInfoUsecase.getMyPenaltyRanking(rankOffset);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/docs/AttendApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/docs/AttendApi.java
@@ -1,12 +1,12 @@
 package com.blackcompany.eeos.target.presentation.docs;
 
-import com.blackcompany.eeos.auth.presentation.support.Member;
 import com.blackcompany.eeos.common.presentation.response.ApiResponse;
 import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
 import com.blackcompany.eeos.common.presentation.response.PageResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfoWithProgramResponse;
 import com.blackcompany.eeos.target.application.dto.AttendInfosSearchRequest;
+import com.blackcompany.eeos.target.application.dto.AttendPenaltyRankingResponse;
 import com.blackcompany.eeos.target.application.dto.AttendPenaltyResponse;
 import com.blackcompany.eeos.target.application.dto.AttendSummaryInfoResponse;
 import com.blackcompany.eeos.target.application.dto.ChangeAttendStatusResponse;
@@ -61,7 +61,7 @@ public interface AttendApi {
 	@Operation(summary = "나의 출석 현황 정보들 조회", description = "나의 출석 현황 정보들을 가져온다.")
 	@GetMapping("/api/attend/programs")
 	ApiResponse<SuccessBody<PageResponse<AttendInfoWithProgramResponse>>> getMyAttendInfosWithProgram(
-			@Member Long memberId, @Valid AttendInfosSearchRequest request);
+			@Valid AttendInfosSearchRequest request);
 
 	@Operation(summary = "벌점 순위 Top 10 조회", description = "전체 회원 중 벌점을 기준으로 Top 10을 조회합니다.")
 	ApiResponse<SuccessBody<PageResponse<AttendPenaltyResponse>>> getPenaltyInfo(
@@ -70,4 +70,7 @@ public interface AttendApi {
 	@Operation(summary = "나의 출석 요약 정보 조회", description = "자신의 출석 요약 정보 (참석 , 지각, 불참, 벌점 통계)를 가져온다.")
 	ApiResponse<SuccessBody<AttendSummaryInfoResponse>> getMyAttendSummaryInfo(
 			Long startDate, Long endDate);
+
+	@Operation(summary = "나의 벌점 순위 조회", description = "나의 벌점 순위를 조회합니다.")
+	ApiResponse<SuccessBody<AttendPenaltyRankingResponse>> getMyPenaltyRankingInfo(int rankOffset);
 }


### PR DESCRIPTION
## 📌 관련 이슈
closes #225 

## ✒️ 작업 내용
- 나의 벌점 순위가 특정 순위 내에 들었는지 조회하는 API 를 구현합니다.
  - rankOffset Request Param 을 통해, 기준이 되는 등수를 전달받아, 해당 순위 이내에 있는지를 T/F 로 반환합니다.
  - 자신의 순위도 반환합니다.
- penaltyList를 조회하는 API를 수정하여, 특정 기간 (startDate, endDate) 동안의 행사를 기준으로 벌점 순위를 조회하도록 변경했습니다.
  - startDate , endDate 는 `required = false`

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 벌점 정보 요청 시 시작일과 종료일을 선택하여 결과를 필터링할 수 있습니다.
	- 사용자별 누적 벌점에 기반한 순위 정보를 확인할 수 있는 새로운 벌점 순위 조회 기능이 추가되었습니다.
	- 캘린더 정보 조회 및 업데이트를 위한 새로운 API 엔드포인트가 추가되었습니다.
	- 캘린더 관련 요청 시 시작일과 종료일을 필수로 입력해야 합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->