### PR TITLE
[CHORE] 개발용 CD 작성

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -1,0 +1,94 @@
+name: CD Deploy
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [ "develop" ]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH 접속 및 배포 실행
+        id: deploy
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.DEV_HOST }}             # 예: 000.000.000.000
+          username: ${{ secrets.DEV_USERNAME }}       # SSH 로그인 사용자
+          password: ${{ secrets.DEV_PASSWORD }}       # SSH 비밀번호
+          port: ${{ secrets.DEV_SSH_PORT }}
+          script: |
+            set -ex
+            cd EEOS-BE/eeos
+            BRANCH="${{ github.event.pull_request.base.ref }}"
+            echo "Deploying for branch: ${BRANCH}"
+            if [ "${BRANCH}" = "develop" ]; then
+              sudo chmod +x ./scripts/deploy-develop.sh
+              ./scripts/deploy-develop.sh
+            else
+              echo "No deployment script available for branch ${BRANCH}"
+              exit 1
+            fi
+      - name: Slack 알림 전송
+        if: always()
+        env:
+          SLACK_CD_WEBHOOK_URL: ${{ secrets.SLACK_CD_WEBHOOK_URL }}
+          COMMIT_MESSAGE: ${{ github.event.pull_request.title }}
+          BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          STATUS: ${{ job.status }}
+          ERROR_MESSAGE: ${{ steps.deploy.outputs.error_message }}
+        run: |
+          if [ "${STATUS}" = "success" ]; then
+            COLOR="#36a64f"
+          else
+            COLOR="#FF0000"
+          fi
+
+          if [ "${BRANCH_NAME}" = "develop" ]; then
+            DEPLOY_TYPE="개발용"
+          else
+            DEPLOY_TYPE="${BRANCH_NAME}"
+          fi
+          
+          LOCAL_TIME=$(TZ="Asia/Seoul" date -d "${MERGED_AT}" +'%Y-%m-%d %H:%M:%S')
+
+          PAYLOAD=$(cat <<EOF
+          {
+            "username": "배포 알림",
+            "attachments": [
+              {
+                "color": "${COLOR}",
+                "title": "${DEPLOY_TYPE} 배포 결과: ${STATUS}",
+                "fields": [
+                  {
+                    "title": "Commit Message",
+                    "value": "\`${COMMIT_MESSAGE}\`",
+                    "short": false
+                  },
+                  {
+                    "title": "브랜치",
+                    "value": "\`${BRANCH_NAME}\`",
+                    "short": false
+                  },
+                  {
+                    "title": "Workflow URL",
+                    "value": "<${WORKFLOW_URL}|자세히 보기>",
+                    "short": false
+                  },
+                  {
+                    "title": "Merged At",
+                    "value": "\`${LOCAL_TIME}\`",
+                    "short": false
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          )
+          
+          echo "$PAYLOAD"
+          curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$SLACK_CD_WEBHOOK_URL"

--- a/eeos/scripts/deploy-develop.sh
+++ b/eeos/scripts/deploy-develop.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+git fetch origin develop
+git reset --hard origin/develop
+
+./gradlew build -x test
+
+sudo docker-compose -f docker-compose-dev.yml down
+
+sudo docker-compose -f docker-compose-dev.yml up --build -d
+


### PR DESCRIPTION
## 📌 관련 이슈
#52 

## ✒️ 작업 내용
### 1. scripts/deploy-develop.sh 
- 개발용 ssh 접속, 코드 최신화 코드 및 배포 코드를에 대한 스크립트 입니다

### 2. backend-cd-dev.yml
- 개발용 서버에 대한 cd 입니다
- develop 브랜치에서 pr 이 머지되었을때 cd 가 실행됩니다
- cd 성공을 위한 조건 
  - ci 성공 -> pr merge ->( pr close)
- ssh sudo 설정
  - sudo 실행시 추가 비밀번호를 받지 않도록 sudo nopasswd 옵션을 설정했습니다
- CD 실행 후 성공 및 실패 여부는 슬랙의 "배포알리미" 채널에 메세지로 전송되도록 설정했습니다
   - 성공시 녹색을, 실패시 붉은색으로 메세지가 전송됩니다

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - PR 병합 후 개발 브랜치에 대한 자동 배포와 관련 결과를 Slack 알림으로 전달하는 자동화 기능을 도입했습니다.
- **유지 관리**
  - 최신 코드 동기화, 빌드 진행 및 컨테이너 재시작을 자동으로 수행하는 배포 스크립트를 추가해 배포 프로세스의 효율성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->