### PR TITLE
[CHORE] 배포후 health check 단계 추가

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -30,6 +30,23 @@ jobs:
               echo "No deployment script available for branch ${BRANCH}"
               exit 1
             fi
+
+      - name: API Health Check
+        id: health_check
+        run: |
+          echo "Waiting for container to start..."
+          sleep 10  
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" https://dev.eeos.co.kr/api/health-check)
+
+          echo "Health Check returned code: $HTTP_CODE"
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+          fi
+
       - name: Slack 알림 전송
         if: always()
         env:
@@ -40,11 +57,25 @@ jobs:
           MERGED_AT: ${{ github.event.pull_request.merged_at }}
           STATUS: ${{ job.status }}
           ERROR_MESSAGE: ${{ steps.deploy.outputs.error_message }}
+          HEALTH_STATUS: ${{ steps.health_check.outputs.status }}
+
         run: |
           if [ "${STATUS}" = "success" ]; then
-            COLOR="#36a64f"
+            BASE_COLOR="#36a64f"
+            DEPLOY_RESULT="성공"
           else
-            COLOR="#FF0000"
+            BASE_COLOR="#FF0000"
+            DEPLOY_RESULT="실패"
+          fi
+          
+          # 헬스 체크 결과
+          if [ "${HEALTH_STATUS}" = "success" ]; then
+            HEALTH_RESULT="성공"
+          elif [ "${HEALTH_STATUS}" = "failure" ]; then
+            HEALTH_RESULT="실패"
+            BASE_COLOR="#FF0000"  # 헬스 체크 실패면 강제로 색상 빨강
+          else
+            HEALTH_RESULT="Health Check 미실시"
           fi
 
           if [ "${BRANCH_NAME}" = "develop" ]; then
@@ -60,9 +91,14 @@ jobs:
             "username": "배포 알림",
             "attachments": [
               {
-                "color": "${COLOR}",
-                "title": "${DEPLOY_TYPE} 배포 결과: ${STATUS}",
+                "color": "${BASE_COLOR}",
+                "title": "${DEPLOY_TYPE} 배포 : ${DEPLOY_RESULT}",
                 "fields": [
+                  {
+                    "title": "Health Check",
+                    "value": "\`${HEALTH_RESULT}\`",
+                    "short": false
+                  },
                   {
                     "title": "Commit Message",
                     "value": "\`${COMMIT_MESSAGE}\`",


### PR DESCRIPTION
## 📌 관련 이슈
closes #229 
## ✒️ 작업 내용
배포 이후 서버가 정상적으로 작동하는지 확인하기 위해 api health check 로직을 추가하고
health check 결과를 슬랙 메세지로 받을 수 있도록 하는 단계를 추가하였습니다.

- [x] api health check 단계 추가
- [x] health check 결과값 슬랙메세지 전송

### 스크린샷 🏞️ (선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b6f2713e-9e5b-4a97-af8c-e7bafd4daf91" />

## 💬 REVIEWER에게 요구사항 💬 
메세지 양식 가독성부분 괜찮으실까요? 
의견주시면 감사하겠습니다~! 