### PR TITLE
[FIX] 3개의 에러를 수정합니다.

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/QueryAnswerResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/QueryAnswerResponse.java
@@ -15,6 +15,6 @@ public class QueryAnswerResponse implements AbstractResponseDto {
 	private Long commentId;
 	private String writer;
 	private String accessRight;
-	private String time;
+	private Long time;
 	private String content;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/QueryCommentResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/QueryCommentResponse.java
@@ -17,7 +17,7 @@ public class QueryCommentResponse implements AbstractResponseDto {
 	private Long teamId;
 	private String writer;
 	private String accessRight;
-	private String time;
+	private Long time;
 	private String content;
 	private List<QueryAnswerResponse> answers;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/converter/CommentResponseConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/converter/CommentResponseConverter.java
@@ -7,10 +7,13 @@ import com.blackcompany.eeos.comment.application.dto.QueryCommentsResponse;
 import com.blackcompany.eeos.comment.application.exception.NotConvertedCommentException;
 import com.blackcompany.eeos.comment.application.model.CommentModel;
 import com.blackcompany.eeos.comment.application.model.CommentType;
+import com.blackcompany.eeos.common.utils.DateConverter;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.xml.stream.events.Comment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +39,7 @@ public class CommentResponseConverter {
 				answers.stream().map(e -> from(e, memberId)).collect(Collectors.toList());
 
 		return QueryCommentResponse.builder()
-				.time(getCreateTimeString(source))
+				.time(getCreateTimeLong(source))
 				.content(source.getContent())
 				.teamId(source.getPresentingTeam())
 				.writer(findMemberName(source.getWriter(), source))
@@ -53,7 +56,7 @@ public class CommentResponseConverter {
 						.commentId(source.getId())
 						.content(source.getContent())
 						.writer(findMemberName(source.getWriter(), source))
-						.time(getCreateTimeString(source))
+						.time(getCreateTimeLong(source))
 						.accessRight(source.getAccessRight(memberId))
 						.build();
 		return response;
@@ -71,5 +74,11 @@ public class CommentResponseConverter {
 				.getCreatedDate()
 				.toLocalDateTime()
 				.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분 ss초"));
+	}
+
+	private Long getCreateTimeLong(CommentModel model){
+		return model
+				.getCreatedDate()
+				.getTime();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/converter/CommentResponseConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/comment/application/dto/converter/CommentResponseConverter.java
@@ -7,13 +7,10 @@ import com.blackcompany.eeos.comment.application.dto.QueryCommentsResponse;
 import com.blackcompany.eeos.comment.application.exception.NotConvertedCommentException;
 import com.blackcompany.eeos.comment.application.model.CommentModel;
 import com.blackcompany.eeos.comment.application.model.CommentType;
-import com.blackcompany.eeos.common.utils.DateConverter;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.xml.stream.events.Comment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -76,9 +73,7 @@ public class CommentResponseConverter {
 				.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분 ss초"));
 	}
 
-	private Long getCreateTimeLong(CommentModel model){
-		return model
-				.getCreatedDate()
-				.getTime();
+	private Long getCreateTimeLong(CommentModel model) {
+		return model.getCreatedDate().getTime();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/dto/AttendSummaryInfoResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/dto/AttendSummaryInfoResponse.java
@@ -3,5 +3,5 @@ package com.blackcompany.eeos.target.application.dto;
 import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
 
 public record AttendSummaryInfoResponse(
-		Long memberId, Long attendCount, Long absentCount, Long penaltyPoint)
+		Long memberId, Long attendCount, Long lateCount, Long absentCount, Long penaltyPoint)
 		implements AbstractResponseDto {}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -232,7 +232,8 @@ public class AttendService
 		Long lateCount = attendCountCalculate.countByStatus(AttendStatus.LATE.getStatus(), attends);
 		Long penaltyPoint = attendCountCalculate.penaltyPoint(attends);
 
-		return new AttendSummaryInfoResponse(memberId, attendCount, lateCount, absentCount, penaltyPoint);
+		return new AttendSummaryInfoResponse(
+				memberId, attendCount, lateCount, absentCount, penaltyPoint);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -232,7 +232,7 @@ public class AttendService
 		Long lateCount = attendCountCalculate.countByStatus(AttendStatus.LATE.getStatus(), attends);
 		Long penaltyPoint = attendCountCalculate.penaltyPoint(attends);
 
-		return new AttendSummaryInfoResponse(memberId, attendCount, absentCount, penaltyPoint);
+		return new AttendSummaryInfoResponse(memberId, attendCount, lateCount, absentCount, penaltyPoint);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
@@ -119,7 +119,7 @@ public class AttendController implements AttendApi {
 	@Override
 	@GetMapping("/attend/summary")
 	public ApiResponse<SuccessBody<AttendSummaryInfoResponse>> getMyAttendSummaryInfo(
-			@RequestParam("startDate") Long startDate, @RequestParam("endDate") Long endDate) {
+			@RequestParam(value = "startDate", required = false) Long startDate, @RequestParam(value = "endDate", required = false) Long endDate) {
 		AttendSummaryInfoResponse response =
 				getAttendantInfoUsecase.getMyAttendSummary(startDate, endDate);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
@@ -119,7 +119,8 @@ public class AttendController implements AttendApi {
 	@Override
 	@GetMapping("/attend/summary")
 	public ApiResponse<SuccessBody<AttendSummaryInfoResponse>> getMyAttendSummaryInfo(
-			@RequestParam(value = "startDate", required = false) Long startDate, @RequestParam(value = "endDate", required = false) Long endDate) {
+			@RequestParam(value = "startDate", required = false) Long startDate,
+			@RequestParam(value = "endDate", required = false) Long endDate) {
 		AttendSummaryInfoResponse response =
 				getAttendantInfoUsecase.getMyAttendSummary(startDate, endDate);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);


### PR DESCRIPTION
## 📌 관련 이슈
#231 

## ✒️ 작업 내용
- 출석 요약 정보 조회 API에서 시작 날자와, 종료 날짜는 `required = false` 로 수정합니다.
- 출석 요약 정보 응답에 lateCount를 추가합니다.
- 코멘트 생성 시각을 timestamp 값으로 반환합니다.

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
	- 출석 요약 응답에 지각 횟수 정보가 추가되어, 보다 상세한 출석 내역을 제공합니다.
	- 출석 조회 시 날짜 필터가 선택 사항으로 변경되어 요청의 유연성이 향상되었습니다.
- **리팩터**
	- 댓글 및 답변의 시간 값이 텍스트에서 숫자형 타임스탬프로 개선되어 응답 데이터의 일관성과 가독성이 높아졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->