### PR TITLE
[FIX] 파이어핑거 멤버 정렬 재설정

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -391,8 +391,6 @@ public class AttendService
 		return memberRepository.findMembersByIdsInOrder(memberIds);
 	}
 
-
-
 	private List<AttendModel> findAttendByAttendStatus(final Long programId, final String status) {
 		AttendStatus attendStatus = AttendStatus.find(status);
 		return attendRepository.findAllByProgramIdAndStatus(programId, attendStatus).stream()

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -201,7 +201,7 @@ public class AttendService
 
 	private List<AttendModel> findTop5Attendants(Long programId) {
 		return attendRepository
-				.findTop5ByProgramIdAndStatusOrderByUpdatedDateAscRankAsc(programId, AttendStatus.ATTEND)
+				.findTop5ByProgramIdAndStatusOrderByRankAsc(programId, AttendStatus.ATTEND)
 				.stream()
 				.map(attendEntityConverter::from)
 				.collect(Collectors.toList());
@@ -381,7 +381,7 @@ public class AttendService
 		List<Long> memberIds =
 				attends.stream().map(AttendModel::getMemberId).collect(Collectors.toList());
 
-		return memberRepository.findMembersByIds(memberIds);
+		return memberRepository.findMembersByIdsInOrder(memberIds);
 	}
 
 	private List<AttendModel> findAttendByAttendStatus(final Long programId, final String status) {

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -189,7 +189,7 @@ public class AttendService
 		validateExistsProgram(programId);
 
 		List<AttendModel> attendModels = findTop5Attendants(programId);
-		List<MemberModel> members = findMembers(attendModels);
+		List<MemberModel> members = findMembersInOrder(attendModels);
 
 		List<AttendInfoResponse> response =
 				members.stream()
@@ -381,8 +381,17 @@ public class AttendService
 		List<Long> memberIds =
 				attends.stream().map(AttendModel::getMemberId).collect(Collectors.toList());
 
+		return memberRepository.findMembersByIds(memberIds);
+	}
+
+	private List<MemberModel> findMembersInOrder(List<AttendModel> attends) {
+		List<Long> memberIds =
+				attends.stream().map(AttendModel::getMemberId).collect(Collectors.toList());
+
 		return memberRepository.findMembersByIdsInOrder(memberIds);
 	}
+
+
 
 	private List<AttendModel> findAttendByAttendStatus(final Long programId, final String status) {
 		AttendStatus attendStatus = AttendStatus.find(status);

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -42,6 +42,8 @@ import com.blackcompany.eeos.target.application.usecase.GetAttendStatusUsecase;
 import com.blackcompany.eeos.target.application.usecase.GetAttendantInfoUsecase;
 import com.blackcompany.eeos.target.persistence.AttendEntity;
 import com.blackcompany.eeos.target.persistence.AttendRepository;
+import com.blackcompany.eeos.target.persistence.ProgramRankCounterEntity;
+import com.blackcompany.eeos.target.persistence.ProgramRankCounterRepository;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -86,6 +88,7 @@ public class AttendService
 	private final ProgramEntityConverter programEntityConverter;
 	private final AttendCountCalculate attendCountCalculate;
 	private final AttendPenaltyResponseConverter attendPenaltyResponseConverter;
+	private final ProgramRankCounterRepository programRankCounterRepository;
 
 	@Override
 	public List<AttendInfoResponse> findAttendInfo(final Long programId) {
@@ -112,6 +115,26 @@ public class AttendService
 	}
 
 	@Transactional
+	public Long getNextRank(Long programId) {
+		ProgramRankCounterEntity counter = programRankCounterRepository.findByProgramIdForUpdate(programId)
+				.orElseGet(() -> createNewCounter(programId));
+
+		Long currentRank = counter.getNextRank();
+		counter.incrementNextRank();
+		return currentRank;
+
+	}
+
+	private ProgramRankCounterEntity createNewCounter(Long programId) {
+		ProgramRankCounterEntity newCounter = ProgramRankCounterEntity.builder()
+				.programId(programId)
+				.nextRank(1L) // 초기값 1로 설정
+				.build();
+		return programRankCounterRepository.save(newCounter);
+	}
+
+
+	@Transactional
 	@Override
 	public ChangeAttendStatusResponse changeStatus(final Long memberId, final Long programId) {
 		AttendModel model = getAttend(memberId, programId);
@@ -123,7 +146,7 @@ public class AttendService
 		AttendModel changedModel = model.changeStatus(program.getAttendMode().getMode());
 
 		if (changedModel.getStatus().equals("attend")) {
-			Long rank = calculateRank(programId);
+			Long rank = getNextRank(programId);
 			changedModel.setRank(rank);
 		}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -116,23 +116,24 @@ public class AttendService
 
 	@Transactional
 	public Long getNextRank(Long programId) {
-		ProgramRankCounterEntity counter = programRankCounterRepository.findByProgramIdForUpdate(programId)
-				.orElseGet(() -> createNewCounter(programId));
+		ProgramRankCounterEntity counter =
+				programRankCounterRepository
+						.findByProgramIdForUpdate(programId)
+						.orElseGet(() -> createNewCounter(programId));
 
 		Long currentRank = counter.getNextRank();
 		counter.incrementNextRank();
 		return currentRank;
-
 	}
 
 	private ProgramRankCounterEntity createNewCounter(Long programId) {
-		ProgramRankCounterEntity newCounter = ProgramRankCounterEntity.builder()
-				.programId(programId)
-				.nextRank(1L) // 초기값 1로 설정
-				.build();
+		ProgramRankCounterEntity newCounter =
+				ProgramRankCounterEntity.builder()
+						.programId(programId)
+						.nextRank(1L) // 초기값 1로 설정
+						.build();
 		return programRankCounterRepository.save(newCounter);
 	}
-
 
 	@Transactional
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -126,6 +126,7 @@ public class AttendService
 		return currentRank;
 	}
 
+	@Transactional
 	private ProgramRankCounterEntity createNewCounter(Long programId) {
 		ProgramRankCounterEntity newCounter =
 				ProgramRankCounterEntity.builder()
@@ -408,10 +409,5 @@ public class AttendService
 		if (!programRepository.existsById(programId)) {
 			throw new NotFoundProgramException(programId);
 		}
-	}
-
-	private Long calculateRank(Long programId) {
-		return attendRepository.countAttendStatusByProgramIdAndStatus(programId, AttendStatus.ATTEND)
-				+ 1;
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -50,7 +50,7 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 	long countAttendStatusByProgramIdAndStatus(
 			@Param("programId") Long programId, @Param("status") AttendStatus status);
 
-	List<AttendEntity> findTop5ByProgramIdAndStatusOrderByUpdatedDateAscRankAsc(
+	List<AttendEntity> findTop5ByProgramIdAndStatusOrderByRankAsc(
 			Long programId, AttendStatus status);
 
 	@Query(

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterEntity.java
@@ -1,0 +1,46 @@
+package com.blackcompany.eeos.target.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(name = ProgramRankCounterEntity.ENTITY_PREFIX)
+public class ProgramRankCounterEntity {
+    public static final String ENTITY_PREFIX = "program_rank_counter";
+
+    @Id
+    @Column(name = ENTITY_PREFIX+"_id", nullable = false)
+    private Long programId;
+
+    @Column(name = ENTITY_PREFIX+"_nextRank", nullable = false)
+    private Long nextRank;
+
+    public void setProgramId(Long programId) {
+        this.programId = programId;
+    }
+
+    public void setNextRank(Long nextRank) {
+        this.nextRank = nextRank;
+    }
+
+    public void incrementNextRank() {
+        this.nextRank = this.nextRank + 1;
+    }
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterEntity.java
@@ -3,7 +3,6 @@ package com.blackcompany.eeos.target.persistence;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,8 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,25 +19,24 @@ import org.hibernate.annotations.Where;
 @Entity
 @Table(name = ProgramRankCounterEntity.ENTITY_PREFIX)
 public class ProgramRankCounterEntity {
-    public static final String ENTITY_PREFIX = "program_rank_counter";
+	public static final String ENTITY_PREFIX = "program_rank_counter";
 
-    @Id
-    @Column(name = ENTITY_PREFIX+"_id", nullable = false)
-    private Long programId;
+	@Id
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long programId;
 
-    @Column(name = ENTITY_PREFIX+"_nextRank", nullable = false)
-    private Long nextRank;
+	@Column(name = ENTITY_PREFIX + "_nextRank", nullable = false)
+	private Long nextRank;
 
-    public void setProgramId(Long programId) {
-        this.programId = programId;
-    }
+	public void setProgramId(Long programId) {
+		this.programId = programId;
+	}
 
-    public void setNextRank(Long nextRank) {
-        this.nextRank = nextRank;
-    }
+	public void setNextRank(Long nextRank) {
+		this.nextRank = nextRank;
+	}
 
-    public void incrementNextRank() {
-        this.nextRank = this.nextRank + 1;
-    }
-
+	public void incrementNextRank() {
+		this.nextRank = this.nextRank + 1;
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterRepository.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.target.persistence;
+
+
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProgramRankCounterRepository extends JpaRepository<ProgramRankCounterEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM ProgramRankCounterEntity c WHERE c.programId = :programId")
+    Optional<ProgramRankCounterEntity> findByProgramIdForUpdate(@Param("programId") Long programId);
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/ProgramRankCounterRepository.java
@@ -1,6 +1,5 @@
 package com.blackcompany.eeos.target.persistence;
 
-
 import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,10 +9,10 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProgramRankCounterRepository extends JpaRepository<ProgramRankCounterEntity, Long> {
+public interface ProgramRankCounterRepository
+		extends JpaRepository<ProgramRankCounterEntity, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT c FROM ProgramRankCounterEntity c WHERE c.programId = :programId")
-    Optional<ProgramRankCounterEntity> findByProgramIdForUpdate(@Param("programId") Long programId);
-
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT c FROM ProgramRankCounterEntity c WHERE c.programId = :programId")
+	Optional<ProgramRankCounterEntity> findByProgramIdForUpdate(@Param("programId") Long programId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/controller/AttendController.java
@@ -90,7 +90,7 @@ public class AttendController implements AttendApi {
 
 	@Override
 	@GetMapping("/attend/programs/fire-finger/{programId}")
-	public ApiResponse<SuccessBody<QueryAttendStatusResponse>> getAttendInfoByTop10(
+	public ApiResponse<SuccessBody<QueryAttendStatusResponse>> getAttendInfoByTop5(
 			@PathVariable("programId") Long programId) {
 		QueryAttendStatusResponse response = getAttendantInfoUsecase.findFireFingerMembers(programId);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);

--- a/eeos/src/main/java/com/blackcompany/eeos/target/presentation/docs/AttendApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/presentation/docs/AttendApi.java
@@ -56,7 +56,7 @@ public interface AttendApi {
 	@Operation(
 			summary = "파이어핑거 top10 회원 조회",
 			description = "PathVariable에 담긴 프로그램를 이용해 특정 프로그램에서 출석을 빠르게 한 사용자의 정보를 가져온다.")
-	ApiResponse<SuccessBody<QueryAttendStatusResponse>> getAttendInfoByTop10(Long programId);
+	ApiResponse<SuccessBody<QueryAttendStatusResponse>> getAttendInfoByTop5(Long programId);
 
 	@Operation(summary = "나의 출석 현황 정보들 조회", description = "나의 출석 현황 정보들을 가져온다.")
 	@GetMapping("/api/attend/programs")


### PR DESCRIPTION
## 📌 관련 이슈
#233 
## ✒️ 작업 내용
- 멤버 조회시 파이어핑거 순위 정렬이 유지 되지 않는 문제가 있었습니다.
- findMembersByIdsInOrder 로 조회하는 로직으로 수정했습니다
- 이외 메소드명과 정렬기준(update_date, rank -> rank)로 재설정했습니다.
### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 프로그램 순위 관리 기능이 추가되어 각 프로그램의 순위가 자동으로 계산되고 업데이트됩니다.
  - 상위 참석자 조회 API가 상위 5명의 참석자를 기준으로 결과를 제공하도록 개선되었습니다.
- **리팩터링**
  - 참석자 정렬 기준이 순위에 맞추어 조정되어 일관된 순위 표시가 보장됩니다.
- **버그 수정**
  - API 메서드 이름이 변경되어 혼란을 줄이고 기능을 명확히 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->