### PR TITLE
[FEAT] 슬랙을 통한 신규 회원가입 막는 로직 주석처리

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/AuthService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/AuthService.java
@@ -1,9 +1,7 @@
 package com.blackcompany.eeos.auth.application.service;
 
 import com.blackcompany.eeos.auth.application.domain.OauthMemberModel;
-import com.blackcompany.eeos.auth.application.domain.OauthServerType;
 import com.blackcompany.eeos.auth.application.exception.NotFoundAccountException;
-import com.blackcompany.eeos.auth.application.exception.OAuthSignupRestrictedException;
 import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
 import com.blackcompany.eeos.auth.persistence.AccountRepository;
@@ -43,9 +41,9 @@ public class AuthService {
 
 	private OauthMemberModel signUpMember(final OauthMemberModel model) {
 		// Slack 신규 유저는 막기
-		if (model.getOauthServerType() == OauthServerType.SLACK) {
-			throw new OAuthSignupRestrictedException(OauthServerType.SLACK.getOauthServer());
-		}
+		//		if (model.getOauthServerType() == OauthServerType.SLACK) {
+		//			throw new OAuthSignupRestrictedException(OauthServerType.SLACK.getOauthServer());
+		//		}
 
 		MemberModel member =
 				MemberModel.builder()

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/AuthServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/AuthServiceTest.java
@@ -14,6 +14,7 @@ import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.model.converter.MemberEntityConverter;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,7 @@ class AuthServiceTest {
 
 	@Test
 	@DisplayName("슬랙을 통한 신규 회원가입은 불가능하다.")
+	@Disabled
 	void sign_up_slack_user() {
 		// given
 		OauthMemberModel slackOAuthMember = FakeOauthMember.oauthMemberModel(OauthServerType.SLACK);


### PR DESCRIPTION
## 📌 관련 이슈
closed #237 

## ✒️ 작업 내용
* 슬랙을 통한 신규회원 가입 막는 로직 주석처리 했습니다.(마찬가지로 테스트 돌아가지 않도록 변경했습니다.)

### 약간의 잡담?
* 왜 controller에서 애초에 serverType이 slack이면 막지 않았을까? 생각했는데요
* 생각해보니... 로그인은 그대로 유지가 되어야 하기 때문에 controller에서 못하고
* authService에서 신규 유저인지 판단하고(oAuthId가 있는지 여부로) 회원가입/로그인 여부를 판단했네요
   * 신규유저 -> oAuthId 존재x
   * 기존유저 -> oAuthId 존재o

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Slack 사용자의 회원가입 제한이 해제되어, 이제 Slack 사용자도 원활하게 회원가입을 진행할 수 있습니다.
- **Tests**
  - Slack 사용자 관련 테스트가 일시적으로 비활성화되어, 테스트 실행 시 해당 항목이 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->