### PR TITLE
[FEAT] 캘린더(시작/종료)날짜 설정/조회

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.program.application.dto.request;
+
+import com.blackcompany.eeos.common.support.dto.AbstractApplicationDto;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CalendarApplicationCommand implements AbstractApplicationDto {
+	private Timestamp startDate;
+	private Timestamp endDate;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/request/CalendarApplicationCommand.java
@@ -1,15 +1,10 @@
 package com.blackcompany.eeos.program.application.dto.request;
 
 import com.blackcompany.eeos.common.support.dto.AbstractApplicationDto;
+import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class CalendarApplicationCommand implements AbstractApplicationDto {
-	private Timestamp startDate;
-	private Timestamp endDate;
-}
+public record CalendarApplicationCommand(
+		@NotNull(message = "시작 날짜는 필수입니다") Timestamp startDate,
+		@NotNull(message = "종료 날짜는 필수입니다") Timestamp endDate)
+		implements AbstractApplicationDto {}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/response/CalendarPeriodApplicationQuery.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/dto/response/CalendarPeriodApplicationQuery.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.program.application.dto.response;
+
+import com.blackcompany.eeos.common.support.dto.AbstractApplicationDto;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CalendarPeriodApplicationQuery implements AbstractApplicationDto {
+	private Timestamp startDate;
+	private Timestamp endDate;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
@@ -35,9 +35,4 @@ public class CalendarModel {
 			endDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.AUGUST, 31).atTime(23, 59, 59));
 		}
 	}
-
-	public void change(Timestamp startDate, Timestamp endDate) {
-		this.startDate = startDate;
-		this.endDate = endDate;
-	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/model/CalendarModel.java
@@ -1,0 +1,43 @@
+package com.blackcompany.eeos.program.application.model;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Slf4j
+public class CalendarModel {
+	private Timestamp startDate;
+	private Timestamp endDate;
+
+	public CalendarModel() {
+		LocalDate now = LocalDate.now();
+
+		// 9월 이후이면 9월 1일부터 다음 해 2월 말까지
+		if (now.getMonthValue() >= Month.SEPTEMBER.getValue()) {
+			startDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.SEPTEMBER, 1).atStartOfDay());
+			endDate =
+					Timestamp.valueOf(
+							LocalDate.of(
+											now.getYear() + 1,
+											Month.FEBRUARY,
+											Month.FEBRUARY.length(Year.isLeap(now.getYear() + 1)))
+									.atTime(23, 59, 59));
+		} else {
+			// 3월 이후이면 3월 1일부터 8월 말까지
+			startDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.MARCH, 1).atStartOfDay());
+			endDate = Timestamp.valueOf(LocalDate.of(now.getYear(), Month.AUGUST, 31).atTime(23, 59, 59));
+		}
+	}
+
+	public void change(Timestamp startDate, Timestamp endDate) {
+		this.startDate = startDate;
+		this.endDate = endDate;
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/repository/CalendarRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/repository/CalendarRepository.java
@@ -1,0 +1,10 @@
+package com.blackcompany.eeos.program.application.repository;
+
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import java.util.Optional;
+
+public interface CalendarRepository {
+	Optional<CalendarModel> getCalendar();
+
+	CalendarModel updateCalendar(CalendarModel model);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
@@ -29,7 +29,7 @@ public class CalendarService implements GetCalendarUsecase, UpdateCalendarUsecas
 	public CalendarPeriodApplicationQuery updateCalendar(CalendarApplicationCommand command) {
 		CalendarModel model =
 				calendarRepository.updateCalendar(
-						new CalendarModel(command.getStartDate(), command.getEndDate()));
+						new CalendarModel(command.startDate(), command.endDate()));
 		return new CalendarPeriodApplicationQuery(model.getStartDate(), model.getEndDate());
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/service/CalendarService.java
@@ -1,0 +1,35 @@
+package com.blackcompany.eeos.program.application.service;
+
+import com.blackcompany.eeos.program.application.dto.request.CalendarApplicationCommand;
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import com.blackcompany.eeos.program.application.repository.CalendarRepository;
+import com.blackcompany.eeos.program.application.support.CalendarProvider;
+import com.blackcompany.eeos.program.application.usecase.GetCalendarUsecase;
+import com.blackcompany.eeos.program.application.usecase.UpdateCalendarUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalendarService implements GetCalendarUsecase, UpdateCalendarUsecase {
+	private final CalendarRepository calendarRepository;
+	private final CalendarProvider calendarProvider;
+
+	@Override
+	public CalendarPeriodApplicationQuery getCalendar() {
+		CalendarModel model = calendarProvider.getCalendar();
+		return new CalendarPeriodApplicationQuery(model.getStartDate(), model.getEndDate());
+	}
+
+	@Override
+	@Transactional
+	public CalendarPeriodApplicationQuery updateCalendar(CalendarApplicationCommand command) {
+		CalendarModel model =
+				calendarRepository.updateCalendar(
+						new CalendarModel(command.getStartDate(), command.getEndDate()));
+		return new CalendarPeriodApplicationQuery(model.getStartDate(), model.getEndDate());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/support/CalendarProvider.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/support/CalendarProvider.java
@@ -1,0 +1,16 @@
+package com.blackcompany.eeos.program.application.support;
+
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import com.blackcompany.eeos.program.application.repository.CalendarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CalendarProvider {
+	private final CalendarRepository calendarRepository;
+
+	public CalendarModel getCalendar() {
+		return calendarRepository.getCalendar().orElse(new CalendarModel());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/GetCalendarUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/GetCalendarUsecase.java
@@ -1,0 +1,7 @@
+package com.blackcompany.eeos.program.application.usecase;
+
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+
+public interface GetCalendarUsecase {
+	CalendarPeriodApplicationQuery getCalendar();
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/UpdateCalendarUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/usecase/UpdateCalendarUsecase.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.program.application.usecase;
+
+import com.blackcompany.eeos.program.application.dto.request.CalendarApplicationCommand;
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+
+public interface UpdateCalendarUsecase {
+	CalendarPeriodApplicationQuery updateCalendar(CalendarApplicationCommand command);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarEntity.java
@@ -1,0 +1,39 @@
+package com.blackcompany.eeos.program.persistence;
+
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import jakarta.persistence.*;
+import java.sql.Timestamp;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(
+		name = CalendarEntity.ENTITY_PREFIX,
+		indexes = {
+			@Index(
+					name = "idx_calendar_created_date_id",
+					columnList = "createdDate DESC, calendar_id DESC")
+		})
+@SQLDelete(sql = "UPDATE calendar SET is_deleted=true where calendar_id=?")
+@Where(clause = "is_deleted=false")
+public class CalendarEntity extends BaseEntity {
+	public static final String ENTITY_PREFIX = "calendar";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(name = ENTITY_PREFIX + "_start_date", nullable = false)
+	private Timestamp startDate;
+
+	@Column(name = ENTITY_PREFIX + "_end_date", nullable = false)
+	private Timestamp endDate;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/persistence/CalendarRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.blackcompany.eeos.program.persistence;
+
+import com.blackcompany.eeos.program.application.model.CalendarModel;
+import com.blackcompany.eeos.program.application.repository.CalendarRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CalendarRepositoryImpl implements CalendarRepository {
+	private final JpaCalendarRepository jpaCalendarRepository;
+
+	@Override
+	public Optional<CalendarModel> getCalendar() {
+		return jpaCalendarRepository.findTopByOrderByCreatedDateDesc().map(this::toModel);
+	}
+
+	@Override
+	public CalendarModel updateCalendar(CalendarModel model) {
+		CalendarEntity entity = toEntity(model);
+		CalendarEntity savedEntity = jpaCalendarRepository.save(entity);
+		return toModel(savedEntity);
+	}
+
+	private CalendarModel toModel(CalendarEntity entity) {
+		return CalendarModel.builder()
+				.startDate(entity.getStartDate())
+				.endDate(entity.getEndDate())
+				.build();
+	}
+
+	private CalendarEntity toEntity(CalendarModel model) {
+		return CalendarEntity.builder()
+				.startDate(model.getStartDate())
+				.endDate(model.getEndDate())
+				.build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/persistence/JpaCalendarRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/persistence/JpaCalendarRepository.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.program.persistence;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCalendarRepository extends JpaRepository<CalendarEntity, Long> {
+	Optional<CalendarEntity> findTopByOrderByCreatedDateDesc();
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/controller/CalendarController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/controller/CalendarController.java
@@ -1,0 +1,38 @@
+package com.blackcompany.eeos.program.presentation.controller;
+
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.response.MessageCode;
+import com.blackcompany.eeos.program.application.dto.request.CalendarApplicationCommand;
+import com.blackcompany.eeos.program.application.dto.response.CalendarPeriodApplicationQuery;
+import com.blackcompany.eeos.program.application.usecase.GetCalendarUsecase;
+import com.blackcompany.eeos.program.application.usecase.UpdateCalendarUsecase;
+import com.blackcompany.eeos.program.presentation.dto.UpdateCalendarRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CalendarController {
+	private final GetCalendarUsecase getCalendarUsecase;
+	private final UpdateCalendarUsecase updateCalendarUsecase;
+
+	@PutMapping("/admin/calendars") // TODO : 인터셉터 단에서 어드민 검증
+	public ApiResponse<ApiResponseBody.SuccessBody<CalendarPeriodApplicationQuery>> updateCalendar(
+			@RequestBody @Valid UpdateCalendarRequest request) {
+		CalendarPeriodApplicationQuery response =
+				updateCalendarUsecase.updateCalendar(
+						new CalendarApplicationCommand(request.startDate(), request.endDate()));
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
+	}
+
+	@GetMapping("/calendars")
+	public ApiResponse<ApiResponseBody.SuccessBody<CalendarPeriodApplicationQuery>> getCalendar() {
+		CalendarPeriodApplicationQuery response = getCalendarUsecase.getCalendar();
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.GET);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.program.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.sql.Timestamp;
+
+public record UpdateCalendarRequest(
+		@NotNull(message = "시작일은 필수값입니다.") Timestamp startDate,
+		@NotNull(message = "종료일은 필수값입니다.") Timestamp endDate) {}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/presentation/dto/UpdateCalendarRequest.java
@@ -1,8 +1,15 @@
 package com.blackcompany.eeos.program.presentation.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.sql.Timestamp;
 
 public record UpdateCalendarRequest(
 		@NotNull(message = "시작일은 필수값입니다.") Timestamp startDate,
-		@NotNull(message = "종료일은 필수값입니다.") Timestamp endDate) {}
+		@NotNull(message = "종료일은 필수값입니다.") Timestamp endDate) {
+
+	@AssertTrue(message = "종료일은 시작일 이후여야 합니다.")
+	public boolean isEndDateAfterStartDate() {
+		return endDate.getTime() > startDate.getTime();
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈
closed #220 

## ✒️ 작업 내용
* 캘린더(시작/종료)날짜 설정/조회입니다.
* `사용하실 때 CalendarProvider의 public 메서드` 가져다 쓰시면, 
   * 어드민에서 설정한 값 있을 경우 -> 해당 값 반환
   * 어드민에서 설정한 값 없을 경우 -> 현 날짜를 기준으로 기본값 반환
       * 기본값
          * 3월 이후인 경우 : 3월 1일 ~ 8월 31일
          * 9월 이후인 경우  : 9월 1일 ~ 2월 마지막날

* 다만, 캘린더 설정의 경우 실제로 어드민인지 validation은 하지 않습니다.
  * 이 경우 토큰 구조 개선(ROLE 추가) 및 인터셉터단에서 어드민인지 validation하도록 해야한다고 생각하여
  * 별도의 PR로 해결합니다.

### 스크린샷 🏞️ (선택)
* 캘린더 조회 API
<img width="1226" alt="image" src="https://github.com/user-attachments/assets/50dd90b1-08cf-4244-8341-66c72bf6d9dc" />

* 캘린더 설정 API ( 어드민 uri 사용)
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/2e5ea1b3-058e-49b7-a645-b86cdf6089c5" />

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 캘린더 관리 기능 추가: 관리자가 캘린더의 시작 및 종료 날짜 정보를 조회하고 업데이트할 수 있는 기능을 도입했습니다.
  - 자동 기본 설정: 현재 날짜에 따라 적절한 기본 캘린더 범위가 동적으로 설정됩니다.
  - REST API 엔드포인트 제공: 캘린더 데이터를 손쉽게 조회 및 수정할 수 있도록 API 인터페이스가 구현되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->