### PR TITLE
[FIX] 나의 출석 현황 리스트 조회 오류를 해결합니다.

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/repository/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/repository/AttendRepository.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.target.application.repository;
 
+import com.blackcompany.eeos.target.application.model.AttendModel;
 import com.blackcompany.eeos.target.application.model.AttendStatus;
 import com.blackcompany.eeos.target.persistence.AttendEntity;
 import java.time.LocalDateTime;
@@ -28,4 +29,6 @@ public interface AttendRepository {
 	List<AttendEntity> findByProgramIdsAndMemberId(List<Long> programIds, Long memberId);
 
 	List<Long> findByPenaltyPointSum(LocalDateTime startDate, LocalDateTime endDate, Long limit);
+
+	List<AttendModel> findMyAttendList(Long memberId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -48,6 +48,7 @@ import com.blackcompany.eeos.target.persistence.PenaltyPointRepository;
 import com.blackcompany.eeos.target.persistence.ProgramRankCounterEntity;
 import com.blackcompany.eeos.target.persistence.ProgramRankCounterRepository;
 import java.sql.Timestamp;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -213,31 +214,34 @@ public class AttendService
 
 		Long memberId = RequestScope.getMemberId();
 
+		Sort.Order order = Sort.Order.desc("createdDate");
+		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(order));
+
 		// 필요한 정보 : ProgramModel , AttendModel, MemberId
-		Page<ProgramModel> pages =
-				programDateRangeService.getPrograms(startDate, endDate, size, page - 1);
+		Page<AttendEntity> myAttend =
+				attendRepository.findAllByMemberIdAndCreatedDateGreaterThan(memberId, new Timestamp(startDate), new Timestamp(endDate), pageable);
+
 
 		Page<AttendInfoWithProgramResponse> responses;
 
-		if (!pages.isEmpty()) {
+		if (!myAttend.isEmpty()) {
 			responses =
 					new PageImpl<>(
-							pages
+							myAttend.stream()
+									.map(attendEntityConverter::from)
 									.map(
-											program -> {
-												AttendModel attendModel =
-														attendRepository
-																.findByProgramIdAndMemberId(program.getId(), memberId)
-																.map(attendEntityConverter::from)
-																.orElse(null);
-												if (attendModel == null) return null;
+											attendModel -> {
+												ProgramModel program =
+																programRepository.findById(attendModel.getProgramId())
+																		.map(programEntityConverter::from)
+																		.orElse(null);
+												if (program == null) return null;
 												return attendInfoWithProgramConverter.from(attendModel, program);
 											})
 									.filter(Objects::nonNull)
-									.stream()
 									.toList(),
-							pages.getPageable(),
-							pages.getTotalElements());
+							myAttend.getPageable(),
+							myAttend.getTotalElements());
 
 			return new PageResponse<>(responses);
 		}

--- a/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/application/service/AttendService.java
@@ -48,7 +48,6 @@ import com.blackcompany.eeos.target.persistence.PenaltyPointRepository;
 import com.blackcompany.eeos.target.persistence.ProgramRankCounterEntity;
 import com.blackcompany.eeos.target.persistence.ProgramRankCounterRepository;
 import java.sql.Timestamp;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -219,8 +218,8 @@ public class AttendService
 
 		// 필요한 정보 : ProgramModel , AttendModel, MemberId
 		Page<AttendEntity> myAttend =
-				attendRepository.findAllByMemberIdAndCreatedDateGreaterThan(memberId, new Timestamp(startDate), new Timestamp(endDate), pageable);
-
+				attendRepository.findAllByMemberIdAndCreatedDateGreaterThan(
+						memberId, new Timestamp(startDate), new Timestamp(endDate), pageable);
 
 		Page<AttendInfoWithProgramResponse> responses;
 
@@ -232,9 +231,10 @@ public class AttendService
 									.map(
 											attendModel -> {
 												ProgramModel program =
-																programRepository.findById(attendModel.getProgramId())
-																		.map(programEntityConverter::from)
-																		.orElse(null);
+														programRepository
+																.findById(attendModel.getProgramId())
+																.map(programEntityConverter::from)
+																.orElse(null);
 												if (program == null) return null;
 												return attendInfoWithProgramConverter.from(attendModel, program);
 											})

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -58,7 +58,8 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 	List<AttendEntity> findByProgramIdsAndMemberId(
 			@Param("programIds") List<Long> programIds, @Param("memberId") Long memberId);
 
-	@Query("SELECT a FROM AttendEntity a WHERE a.memberId = :memberId AND a.isDeleted = false AND a.createdDate > :startDate AND a.createdDate < :endDate")
+	@Query(
+			"SELECT a FROM AttendEntity a WHERE a.memberId = :memberId AND a.isDeleted = false AND a.createdDate > :startDate AND a.createdDate < :endDate")
 	Page<AttendEntity> findAllByMemberIdAndCreatedDateGreaterThan(
 			@Param("memberId") Long memberId,
 			@Param("startDate") Timestamp startDate,

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.target.persistence;
 
 import com.blackcompany.eeos.target.application.model.AttendStatus;
 import jakarta.persistence.LockModeType;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -54,4 +55,8 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 			"SELECT a FROM AttendEntity a WHERE a.programId IN :programIds AND a.memberId=:memberId AND a.isDeleted=false")
 	List<AttendEntity> findByProgramIdsAndMemberId(
 			@Param("programIds") List<Long> programIds, @Param("memberId") Long memberId);
+
+	@Query("SELECT a FROM AttendEntity a WHERE a.memberId = :memberId AND a.isDeleted = false AND a.createdDate > :startDate AND a.createdDate < :endDate")
+	List<AttendEntity> findAllByMemberIdAndCreatedDateGreaterThan(
+			@Param("memberId") Long memberId, @Param("createdDate") Timestamp createdDate, @Param("endDate") Timestamp endDate);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/target/persistence/AttendRepository.java
@@ -5,6 +5,8 @@ import jakarta.persistence.LockModeType;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -57,6 +59,9 @@ public interface AttendRepository extends JpaRepository<AttendEntity, Long> {
 			@Param("programIds") List<Long> programIds, @Param("memberId") Long memberId);
 
 	@Query("SELECT a FROM AttendEntity a WHERE a.memberId = :memberId AND a.isDeleted = false AND a.createdDate > :startDate AND a.createdDate < :endDate")
-	List<AttendEntity> findAllByMemberIdAndCreatedDateGreaterThan(
-			@Param("memberId") Long memberId, @Param("createdDate") Timestamp createdDate, @Param("endDate") Timestamp endDate);
+	Page<AttendEntity> findAllByMemberIdAndCreatedDateGreaterThan(
+			@Param("memberId") Long memberId,
+			@Param("startDate") Timestamp startDate,
+			@Param("endDate") Timestamp endDate,
+			Pageable pageable);
 }


### PR DESCRIPTION
## 📌 관련 이슈
closes #243 

## ✒️ 작업 내용
- 출석 리스트를 조회할 때, 전체 Program 데이터를 기준으로 조회하여, pageInfo (전체 페이지 수, 한 페이지 당 사이즈 등) 가 전체 Program 데이터를 기준으로 조회가 되는 경우가 발생했습니다.
- 전체 Program 데이터가  아닌, 나의 attend 데이터를 기준으로 조회하여 오류를 수정합니다.

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 특정 멤버의 출석 기록을 지정 기간 내에 조회할 수 있도록 기능이 확장되었습니다.
  - 출석 정보 조회 로직이 개선되어, 페이징 처리와 응답 구성이 더욱 효율적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->