### PR TITLE
[REFACTOR] Calendar Response ID 키 변경

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/calendar/application/dto/CalendarResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/calendar/application/dto/CalendarResponse.java
@@ -6,7 +6,7 @@ import com.blackcompany.eeos.common.utils.DateConverter;
 import java.util.Locale;
 
 public record CalendarResponse(
-		Long id, String title, String url, String type, Long startAt, Long endAt, String writer)
+		Long calendarId, String title, String url, String type, Long startAt, Long endAt, String writer)
 		implements AbstractResponseDto {
 
 	public static CalendarResponse toResponse(CalendarModel model, String writerName) {

--- a/eeos/src/main/java/com/blackcompany/eeos/calendar/application/exception/DeniedCalendarTypeException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/calendar/application/exception/DeniedCalendarTypeException.java
@@ -16,6 +16,6 @@ public class DeniedCalendarTypeException extends BusinessException {
 
 	@Override
 	public String getMessage() {
-		return String.format("%s 부서는 해당 타입의 칼렌더를 생성할 수 없습니다.", department.name());
+		return String.format("%s 부서는 해당 타입의 칼렌더를 생성할 수 없습니다.", department.getKoName());
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈

## ✒️ 작업 내용
- Calendar Response 의 `id` 키를 `calendarId` 로 변경합니다.
- DeniedCalendarTypeException 의 예외 메세지를, 한글 부서 이름이 출력되도록 변경하였습니다.

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 캘린더 API 응답의 식별자 필드명이 id → calendarId로 변경되었습니다. 기타 필드와 구조는 동일합니다. 클라이언트는 해당 필드 참조를 calendarId로 업데이트해야 하며, 구버전 클라이언트는 배포 전 점검을 권장합니다.
* **Bug Fixes**
  * 캘린더 관련 예외 메시지가 부서를 한국어명으로 표시하도록 변경되어 오류 메시지가 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->