### PR TITLE
[FEAT] ADMIN 행사 생성 시, Calendar 반영 로직 추가

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/calendar/application/dto/CalendarResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/calendar/application/dto/CalendarResponse.java
@@ -6,7 +6,7 @@ import com.blackcompany.eeos.common.utils.DateConverter;
 import java.util.Locale;
 
 public record CalendarResponse(
-		Long id, String title, String url, String type, Long startAt, Long endAt, String writer)
+		Long calendarId, String title, String url, String type, Long startAt, Long endAt, String writer)
 		implements AbstractResponseDto {
 
 	public static CalendarResponse toResponse(CalendarModel model, String writerName) {

--- a/eeos/src/main/java/com/blackcompany/eeos/calendar/application/exception/DeniedCalendarTypeException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/calendar/application/exception/DeniedCalendarTypeException.java
@@ -16,6 +16,6 @@ public class DeniedCalendarTypeException extends BusinessException {
 
 	@Override
 	public String getMessage() {
-		return String.format("%s 부서는 해당 타입의 칼렌더를 생성할 수 없습니다.", department.name());
+		return String.format("%s 부서는 해당 타입의 칼렌더를 생성할 수 없습니다.", department.getKoName());
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/calendar/persistence/CalendarEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/calendar/persistence/CalendarEntity.java
@@ -51,7 +51,7 @@ public class CalendarEntity extends BaseEntity {
 	@Column(name = ENTITY_PREFIX + "_title", nullable = false)
 	private String title;
 
-	@Column(name = ENTITY_PREFIX + "_url", nullable = false)
+	@Column(name = ENTITY_PREFIX + "_url", nullable = true)
 	private String url;
 
 	@Column(name = ENTITY_PREFIX + "_start_at", nullable = false)

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEvent.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEvent.java
@@ -1,0 +1,16 @@
+package com.blackcompany.eeos.program.application.event;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreatedProgramEvent {
+
+    private final Long programId;
+
+    public static CreatedProgramEvent of(Long programId){
+        return new CreatedProgramEvent(programId);
+    }
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEvent.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEvent.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreatedProgramEvent {
 
-    private final Long programId;
+	private final Long programId;
 
-    public static CreatedProgramEvent of(Long programId){
-        return new CreatedProgramEvent(programId);
-    }
+	public static CreatedProgramEvent of(Long programId) {
+		return new CreatedProgramEvent(programId);
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEventListener.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEventListener.java
@@ -1,0 +1,45 @@
+package com.blackcompany.eeos.program.application.event;
+
+import com.blackcompany.eeos.calendar.application.dto.CalendarCreateCommand;
+import com.blackcompany.eeos.calendar.application.model.CalendarType;
+import com.blackcompany.eeos.calendar.application.usecase.CreateCalendarUsecase;
+import com.blackcompany.eeos.program.application.exception.NotFoundProgramException;
+import com.blackcompany.eeos.program.application.model.ProgramModel;
+import com.blackcompany.eeos.program.application.model.converter.ProgramEntityConverter;
+import com.blackcompany.eeos.program.persistence.ProgramRepository;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CreatedProgramEventListener {
+
+    private final CreateCalendarUsecase calendarUsecase;
+    private final ProgramRepository programRepository;
+    private final ProgramEntityConverter entityConverter;
+
+    @Transactional
+    @TransactionalEventListener(value = CreatedProgramEvent.class, phase = TransactionPhase.AFTER_COMMIT)
+    public void createCalendar(CreatedProgramEvent event){
+        Long programId = event.getProgramId();
+
+        ProgramModel program = entityConverter.from(programRepository.findById(programId)
+                .orElseThrow(() -> new NotFoundProgramException(programId)));
+
+        Long programDateMilli = program.getProgramDate().toInstant().toEpochMilli();
+
+        CalendarCreateCommand command = new CalendarCreateCommand(
+                program.getTitle(),
+                null,
+                CalendarType.PRESENTATION.name().toLowerCase(Locale.ROOT),
+                programDateMilli,
+                programDateMilli);
+
+        calendarUsecase.create(command);
+    }
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEventListener.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEventListener.java
@@ -10,6 +10,7 @@ import com.blackcompany.eeos.program.persistence.ProgramRepository;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -22,7 +23,7 @@ public class CreatedProgramEventListener {
     private final ProgramRepository programRepository;
     private final ProgramEntityConverter entityConverter;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(value = CreatedProgramEvent.class, phase = TransactionPhase.AFTER_COMMIT)
     public void createCalendar(CreatedProgramEvent event){
         Long programId = event.getProgramId();

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEventListener.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/event/CreatedProgramEventListener.java
@@ -19,28 +19,33 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class CreatedProgramEventListener {
 
-    private final CreateCalendarUsecase calendarUsecase;
-    private final ProgramRepository programRepository;
-    private final ProgramEntityConverter entityConverter;
+	private final CreateCalendarUsecase calendarUsecase;
+	private final ProgramRepository programRepository;
+	private final ProgramEntityConverter entityConverter;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @TransactionalEventListener(value = CreatedProgramEvent.class, phase = TransactionPhase.AFTER_COMMIT)
-    public void createCalendar(CreatedProgramEvent event){
-        Long programId = event.getProgramId();
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@TransactionalEventListener(
+			value = CreatedProgramEvent.class,
+			phase = TransactionPhase.AFTER_COMMIT)
+	public void createCalendar(CreatedProgramEvent event) {
+		Long programId = event.getProgramId();
 
-        ProgramModel program = entityConverter.from(programRepository.findById(programId)
-                .orElseThrow(() -> new NotFoundProgramException(programId)));
+		ProgramModel program =
+				entityConverter.from(
+						programRepository
+								.findById(programId)
+								.orElseThrow(() -> new NotFoundProgramException(programId)));
 
-        Long programDateMilli = program.getProgramDate().toInstant().toEpochMilli();
+		Long programDateMilli = program.getProgramDate().toInstant().toEpochMilli();
 
-        CalendarCreateCommand command = new CalendarCreateCommand(
-                program.getTitle(),
-                null,
-                CalendarType.PRESENTATION.name().toLowerCase(Locale.ROOT),
-                programDateMilli,
-                programDateMilli);
+		CalendarCreateCommand command =
+				new CalendarCreateCommand(
+						program.getTitle(),
+						null,
+						CalendarType.PRESENTATION.name().toLowerCase(Locale.ROOT),
+						programDateMilli,
+						programDateMilli);
 
-        calendarUsecase.create(command);
-    }
-
+		calendarUsecase.create(command);
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/application/service/ProgramService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/application/service/ProgramService.java
@@ -15,6 +15,7 @@ import com.blackcompany.eeos.program.application.dto.UpdateProgramRequest;
 import com.blackcompany.eeos.program.application.dto.converter.ProgramPageResponseConverter;
 import com.blackcompany.eeos.program.application.dto.converter.ProgramResponseConverter;
 import com.blackcompany.eeos.program.application.dto.converter.QueryAccessRightResponseConverter;
+import com.blackcompany.eeos.program.application.event.CreatedProgramEvent;
 import com.blackcompany.eeos.program.application.event.DeletedProgramEvent;
 import com.blackcompany.eeos.program.application.exception.DeniedProgramEditException;
 import com.blackcompany.eeos.program.application.exception.NotFoundProgramException;
@@ -91,6 +92,8 @@ public class ProgramService
 		attendTargetService.save(saveId, request.getMembers());
 		presentTeamUsecase.save(saveId, request.getTeamIds());
 		quitUsecase.reserveQuitProgram(model.toBuilder().id(saveId).build());
+
+		applicationEventPublisher.publishEvent(CreatedProgramEvent.of(saveId));
 
 		return responseConverter.from(saveId);
 	}


### PR DESCRIPTION
## 📌 관련 이슈

## ✒️ 작업 내용
- 행사 생성 이벤트를 발행하여, Calendar 를 생성하도록 구현하였습니다.
- 행사 생성 완료 트랜잭션이 커밋이 된 후에, Calendar가 생성될 수 있도록, @TransactionalEventListener 를 사용하였습니다.

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 

