### PR TITLE
[FEAT] 알림 토큰 생성, 삭제 API 구현

### DIFF
--- a/eeos/build.gradle.kts
+++ b/eeos/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
 
     // OpenFeign
     implementation(libs.spring.cloud.starter.openfeign)
+
+    // Firebase Admin SDK
+    implementation(libs.firebase.admin)
+
 }
 
 dependencyManagement {

--- a/eeos/gradle/libs.versions.toml
+++ b/eeos/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ spotless = "7.2.1"
 asciidoctor = "4.0.2"
 epages-restdocs = "0.18.2"
 swagger = "5.10.3"
+firebase-admin = "9.2.0"
 
 # Security
 jwt = "0.12.6"
@@ -56,6 +57,9 @@ jbcrypt = { group = "org.mindrot", name = "jbcrypt", version.ref = "jbcrypt" }
 
 # Lombok
 lombok = { group = "org.projectlombok", name = "lombok" }
+
+# Firebase Admin SDK
+firebase-admin = { group = "com.google.firebase", name = "firebase-admin", version.ref = "firebase-admin" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
@@ -87,7 +87,8 @@ public class SecurityFilterChainConfig {
 							.requestMatchers("/api/admin/**")
 							.requestMatchers("/api/team-building/**")
 							.requestMatchers("/api/semester-periods/**")
-							.requestMatchers("/api/calendars/**");
+							.requestMatchers("/api/calendars/**")
+						.requestMatchers("/api/pushToken","/api/pushToken/**");
 				});
 
 		httpSecurity.authorizeHttpRequests(

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
@@ -88,7 +88,7 @@ public class SecurityFilterChainConfig {
 							.requestMatchers("/api/team-building/**")
 							.requestMatchers("/api/semester-periods/**")
 							.requestMatchers("/api/calendars/**")
-						.requestMatchers("/api/pushToken","/api/pushToken/**");
+							.requestMatchers("/api/pushToken", "/api/pushToken/**");
 				});
 
 		httpSecurity.authorizeHttpRequests(

--- a/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberFcmTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberFcmTokenEntity.java
@@ -1,4 +1,0 @@
-package com.blackcompany.eeos.member.persistence;
-
-public class MemberFcmTokenEntity {
-}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberFcmTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberFcmTokenEntity.java
@@ -1,0 +1,4 @@
+package com.blackcompany.eeos.member.persistence;
+
+public class MemberFcmTokenEntity {
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/dto/CreateMemberPushTokenRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/dto/CreateMemberPushTokenRequest.java
@@ -1,6 +1,6 @@
 package com.blackcompany.eeos.notification.application.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder(toBuilder = true)
 public class CreateMemberPushTokenRequest {
-	@NotNull private String pushToken;
-	@NotNull private String provider;
+	@NotBlank private String pushToken;
+	@NotBlank private String provider;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/dto/CreateMemberPushTokenRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/dto/CreateMemberPushTokenRequest.java
@@ -1,0 +1,16 @@
+package com.blackcompany.eeos.notification.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class CreateMemberPushTokenRequest {
+	@NotNull private String pushToken;
+	@NotNull private String provider;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/dto/DeleteMemberPushTokenRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/dto/DeleteMemberPushTokenRequest.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.notification.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class DeleteMemberPushTokenRequest {
+	@NotBlank private String pushToken;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DeniedDeletePushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DeniedDeletePushTokenException.java
@@ -1,19 +1,17 @@
 package com.blackcompany.eeos.notification.application.exception;
 
+import com.blackcompany.eeos.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
-import com.blackcompany.eeos.common.exception.BusinessException;
-
 public class DeniedDeletePushTokenException extends BusinessException {
-  private static final String FAIL_CODE = "5008";
+	private static final String FAIL_CODE = "5008";
 
-  public DeniedDeletePushTokenException() {
+	public DeniedDeletePushTokenException() {
 		super(FAIL_CODE, HttpStatus.UNAUTHORIZED);
-  }
+	}
 
-  @Override
-  public String getMessage() {
-    return "토큰 수정 권한이 없습니다.";
-  }
-
+	@Override
+	public String getMessage() {
+		return "토큰 수정 권한이 없습니다.";
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DeniedDeletePushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DeniedDeletePushTokenException.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.notification.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+
+public class DeniedDeletePushTokenException extends BusinessException {
+  private static final String FAIL_CODE = "5008";
+
+  public DeniedDeletePushTokenException() {
+		super(FAIL_CODE, HttpStatus.UNAUTHORIZED);
+  }
+
+  @Override
+  public String getMessage() {
+    return "토큰 수정 권한이 없습니다.";
+  }
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DeniedDeletePushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DeniedDeletePushTokenException.java
@@ -7,7 +7,7 @@ public class DeniedDeletePushTokenException extends BusinessException {
 	private static final String FAIL_CODE = "5008";
 
 	public DeniedDeletePushTokenException() {
-		super(FAIL_CODE, HttpStatus.UNAUTHORIZED);
+		super(FAIL_CODE, HttpStatus.FORBIDDEN);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundNotificationProviderException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundNotificationProviderException.java
@@ -1,18 +1,20 @@
 package com.blackcompany.eeos.notification.application.exception;
 
-import org.springframework.http.HttpStatus;
-
 import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 
 public class NotFoundNotificationProviderException extends BusinessException {
 
-  private static final String FAIL_CODE = "5006";
-  private final String provider;
+	private static final String FAIL_CODE = "5006";
+	private final String provider;
+
 	public NotFoundNotificationProviderException(String provider) {
 		super(FAIL_CODE, HttpStatus.NOT_FOUND);
-        this.provider = provider;
+		this.provider = provider;
 	}
 
-    @Override
-    public String getMessage() { return String.format("%s 는 존재하지 않는 외부 제공자 입니다.", provider);}
+	@Override
+	public String getMessage() {
+		return String.format("%s 는 존재하지 않는 외부 제공자 입니다.", provider);
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundNotificationProviderException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundNotificationProviderException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.notification.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+
+public class NotFoundNotificationProviderException extends BusinessException {
+
+  private static final String FAIL_CODE = "5006";
+  private final String provider;
+	public NotFoundNotificationProviderException(String provider) {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+        this.provider = provider;
+	}
+
+    @Override
+    public String getMessage() { return String.format("%s 는 존재하지 않는 외부 제공자 입니다.", provider);}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundPushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundPushTokenException.java
@@ -6,16 +6,14 @@ import org.springframework.http.HttpStatus;
 public class NotFoundPushTokenException extends BusinessException {
 
 	private static final String FAIL_CODE = "5007";
-	private final String pushToken;
 
-	public NotFoundPushTokenException(String pushToken) {
+	public NotFoundPushTokenException() {
 
 		super(FAIL_CODE, HttpStatus.NOT_FOUND);
-		this.pushToken = pushToken;
 	}
 
 	@Override
 	public String getMessage() {
-		return String.format("%s 는 존재하지 않는 알림토큰 입니다.", pushToken);
+		return "존재하지 않는 알림토큰 입니다.";
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundPushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundPushTokenException.java
@@ -1,0 +1,21 @@
+package com.blackcompany.eeos.notification.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+
+public class NotFoundPushTokenException extends BusinessException {
+
+	private static final String FAIL_CODE = "5007";
+	private final String pushToken;
+	public NotFoundPushTokenException(String pushToken) {
+
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+		this.pushToken = pushToken;
+	}
+
+	@Override
+	public String getMessage() {
+		return String.format("%s 는 존재하지 않는 알림토큰 입니다.", pushToken);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundPushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundPushTokenException.java
@@ -1,13 +1,13 @@
 package com.blackcompany.eeos.notification.application.exception;
 
-import org.springframework.http.HttpStatus;
-
 import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
 
 public class NotFoundPushTokenException extends BusinessException {
 
 	private static final String FAIL_CODE = "5007";
 	private final String pushToken;
+
 	public NotFoundPushTokenException(String pushToken) {
 
 		super(FAIL_CODE, HttpStatus.NOT_FOUND);

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
@@ -1,9 +1,6 @@
 package com.blackcompany.eeos.notification.application.model;
 
-import java.time.LocalDateTime;
-
 import com.blackcompany.eeos.common.support.AbstractModel;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
@@ -1,5 +1,7 @@
 package com.blackcompany.eeos.notification.application.model;
 
+import java.time.LocalDateTime;
+
 import com.blackcompany.eeos.common.support.AbstractModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberPushTokenModel implements AbstractModel {
@@ -15,4 +17,12 @@ public class MemberPushTokenModel implements AbstractModel {
 	private Long memberId;
 	private NotificationProvider notificationProvider;
 	private String pushToken;
+	private LocalDateTime lastActiveAt;
+
+	public MemberPushTokenModel renew(Long memberId){
+		return this.toBuilder()
+			.memberId(memberId)
+			.lastActiveAt(LocalDateTime.now())
+			.build();
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
@@ -1,8 +1,7 @@
 package com.blackcompany.eeos.notification.application.model;
 
-import java.time.LocalDateTime;
-
 import com.blackcompany.eeos.common.support.AbstractModel;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,10 +18,7 @@ public class MemberPushTokenModel implements AbstractModel {
 	private String pushToken;
 	private LocalDateTime lastActiveAt;
 
-	public MemberPushTokenModel renew(Long memberId){
-		return this.toBuilder()
-			.memberId(memberId)
-			.lastActiveAt(LocalDateTime.now())
-			.build();
+	public MemberPushTokenModel renew(Long memberId) {
+		return this.toBuilder().memberId(memberId).lastActiveAt(LocalDateTime.now()).build();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
@@ -18,6 +18,4 @@ public class MemberPushTokenModel implements AbstractModel {
 	private Long memberId;
 	private NotificationProvider notificationProvider;
 	private String pushToken;
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/MemberPushTokenModel.java
@@ -1,0 +1,23 @@
+package com.blackcompany.eeos.notification.application.model;
+
+import java.time.LocalDateTime;
+
+import com.blackcompany.eeos.common.support.AbstractModel;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberPushTokenModel implements AbstractModel {
+	private Long id;
+	private Long memberId;
+	private NotificationProvider notificationProvider;
+	private String pushToken;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/NotificationProvider.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/NotificationProvider.java
@@ -1,9 +1,7 @@
 package com.blackcompany.eeos.notification.application.model;
 
-import java.util.Arrays;
-
 import com.blackcompany.eeos.notification.application.exception.NotFoundNotificationProviderException;
-
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
@@ -17,11 +15,10 @@ public enum NotificationProvider {
 		this.provider = provider;
 	}
 
-	public static NotificationProvider find(String name){
+	public static NotificationProvider find(String name) {
 		return Arrays.stream(NotificationProvider.values())
-			.filter(provider -> provider.name().equalsIgnoreCase(name))
-			.findFirst()
-			.orElseThrow(() -> new NotFoundNotificationProviderException(name));
+				.filter(provider -> provider.name().equalsIgnoreCase(name))
+				.findFirst()
+				.orElseThrow(() -> new NotFoundNotificationProviderException(name));
 	}
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/NotificationProvider.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/NotificationProvider.java
@@ -1,0 +1,27 @@
+package com.blackcompany.eeos.notification.application.model;
+
+import java.util.Arrays;
+
+import com.blackcompany.eeos.notification.application.exception.NotFoundNotificationProviderException;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationProvider {
+	FCM("fcm"),
+	ETC("etc");
+
+	private final String provider;
+
+	NotificationProvider(String provider) {
+		this.provider = provider;
+	}
+
+	public static NotificationProvider find(String name){
+		return Arrays.stream(NotificationProvider.values())
+			.filter(provider -> provider.name().equalsIgnoreCase(name))
+			.findFirst()
+			.orElseThrow(() -> new NotFoundNotificationProviderException(name));
+	}
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/converter/MemberPushTokenEntityConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/converter/MemberPushTokenEntityConverter.java
@@ -1,31 +1,31 @@
 package com.blackcompany.eeos.notification.application.model.converter;
 
-import org.springframework.stereotype.Component;
-
 import com.blackcompany.eeos.common.support.converter.AbstractEntityConverter;
 import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
 import com.blackcompany.eeos.notification.persistence.MemberPushTokenEntity;
+import org.springframework.stereotype.Component;
 
 @Component
-public class MemberPushTokenEntityConverter implements AbstractEntityConverter<MemberPushTokenEntity, MemberPushTokenModel> {
+public class MemberPushTokenEntityConverter
+		implements AbstractEntityConverter<MemberPushTokenEntity, MemberPushTokenModel> {
 
 	@Override
 	public MemberPushTokenModel from(MemberPushTokenEntity source) {
 		return MemberPushTokenModel.builder()
-			.id(source.getId())
-			.memberId(source.getMemberId())
-			.notificationProvider(source.getProvider())
-			.pushToken(source.getPushToken())
-			.build();
+				.id(source.getId())
+				.memberId(source.getMemberId())
+				.notificationProvider(source.getProvider())
+				.pushToken(source.getPushToken())
+				.build();
 	}
 
 	@Override
 	public MemberPushTokenEntity toEntity(MemberPushTokenModel source) {
 		return MemberPushTokenEntity.builder()
-			.id(source.getId())
-			.memberId(source.getMemberId())
-			.pushToken(source.getPushToken())
-			.provider(source.getNotificationProvider())
-			.build();
+				.id(source.getId())
+				.memberId(source.getMemberId())
+				.pushToken(source.getPushToken())
+				.provider(source.getNotificationProvider())
+				.build();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/converter/MemberPushTokenEntityConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/converter/MemberPushTokenEntityConverter.java
@@ -16,6 +16,7 @@ public class MemberPushTokenEntityConverter
 				.memberId(source.getMemberId())
 				.notificationProvider(source.getProvider())
 				.pushToken(source.getPushToken())
+				.lastActiveAt(source.getLastActiveAt())
 				.build();
 	}
 
@@ -26,6 +27,7 @@ public class MemberPushTokenEntityConverter
 				.memberId(source.getMemberId())
 				.pushToken(source.getPushToken())
 				.provider(source.getNotificationProvider())
+				.lastActiveAt(source.getLastActiveAt())
 				.build();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/converter/MemberPushTokenEntityConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/model/converter/MemberPushTokenEntityConverter.java
@@ -1,0 +1,31 @@
+package com.blackcompany.eeos.notification.application.model.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.blackcompany.eeos.common.support.converter.AbstractEntityConverter;
+import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
+import com.blackcompany.eeos.notification.persistence.MemberPushTokenEntity;
+
+@Component
+public class MemberPushTokenEntityConverter implements AbstractEntityConverter<MemberPushTokenEntity, MemberPushTokenModel> {
+
+	@Override
+	public MemberPushTokenModel from(MemberPushTokenEntity source) {
+		return MemberPushTokenModel.builder()
+			.id(source.getId())
+			.memberId(source.getMemberId())
+			.notificationProvider(source.getProvider())
+			.pushToken(source.getPushToken())
+			.build();
+	}
+
+	@Override
+	public MemberPushTokenEntity toEntity(MemberPushTokenModel source) {
+		return MemberPushTokenEntity.builder()
+			.id(source.getId())
+			.memberId(source.getMemberId())
+			.pushToken(source.getPushToken())
+			.provider(source.getNotificationProvider())
+			.build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
@@ -16,7 +16,7 @@ public interface MemberPushTokenRepository {
 
 	void deleteByPushToken(String pushToken);
 
-	int deleteByMemberId(Long memberId);
+	void deleteByMemberId(Long memberId);
 
 	int deleteByUpdatedDateBefore(LocalDateTime updatedDate);
 

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
@@ -14,6 +14,8 @@ public interface MemberPushTokenRepository {
 	List<MemberPushTokenModel> findByMemberIdAndProvider(
 			Long memberId, NotificationProvider provider);
 
+	Optional<MemberPushTokenModel> findByMemberIdAndPushToken(Long memberId, String pushToken);
+
 	void deleteByPushToken(String pushToken);
 
 	void deleteByMemberId(Long memberId);

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
@@ -1,4 +1,4 @@
-package com.blackcompany.eeos.notification.application.respository;
+package com.blackcompany.eeos.notification.application.repository;
 
 import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/respository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/respository/MemberPushTokenRepository.java
@@ -1,19 +1,18 @@
 package com.blackcompany.eeos.notification.application.respository;
 
-import java.sql.Timestamp;
+import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
-import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 
 public interface MemberPushTokenRepository {
 	Optional<MemberPushTokenModel> findByPushToken(String pushToken);
 
 	List<MemberPushTokenModel> findByMemberId(Long memberId);
 
-	List<MemberPushTokenModel> findByMemberIdAndProvider(Long memberId, NotificationProvider provider);
+	List<MemberPushTokenModel> findByMemberIdAndProvider(
+			Long memberId, NotificationProvider provider);
 
 	void deleteByPushToken(String pushToken);
 
@@ -22,5 +21,4 @@ public interface MemberPushTokenRepository {
 	int deleteByUpdatedDateBefore(LocalDateTime updatedDate);
 
 	MemberPushTokenModel save(MemberPushTokenModel memberPushToken);
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/respository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/respository/MemberPushTokenRepository.java
@@ -1,0 +1,26 @@
+package com.blackcompany.eeos.notification.application.respository;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
+
+public interface MemberPushTokenRepository {
+	Optional<MemberPushTokenModel> findByPushToken(String pushToken);
+
+	List<MemberPushTokenModel> findByMemberId(Long memberId);
+
+	List<MemberPushTokenModel> findByMemberIdAndProvider(Long memberId, NotificationProvider provider);
+
+	void deleteByPushToken(String pushToken);
+
+	int deleteByMemberId(Long memberId);
+
+	int deleteByUpdatedDateBefore(LocalDateTime updatedDate);
+
+	MemberPushTokenModel save(MemberPushTokenModel memberPushToken);
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -6,7 +6,7 @@ import com.blackcompany.eeos.notification.application.exception.DeniedDeletePush
 import com.blackcompany.eeos.notification.application.exception.NotFoundPushTokenException;
 import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
-import com.blackcompany.eeos.notification.application.respository.MemberPushTokenRepository;
+import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
 import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTokenUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
@@ -55,7 +55,7 @@ public class NotificationTokenService
 		MemberPushTokenModel model =
 				memberPushTokenRepository
 						.findByPushToken(request.getPushToken())
-						.orElseThrow(() -> new NotFoundPushTokenException(request.getPushToken()));
+						.orElseThrow(NotFoundPushTokenException::new);
 		if (!model.getMemberId().equals(memberId)) {
 			throw new DeniedDeletePushTokenException();
 		}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -1,5 +1,7 @@
 package com.blackcompany.eeos.notification.application.service;
 
+import java.time.LocalDateTime;
+
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.exception.DeniedDeletePushTokenException;
@@ -27,18 +29,18 @@ public class NotificationTokenService
 	@Override
 	@Transactional
 	public void create(Long memberId, CreateMemberPushTokenRequest request) {
-
 		NotificationProvider provider = NotificationProvider.find(request.getProvider());
-		if (memberPushTokenRepository.findByPushToken(request.getPushToken()).isEmpty()) {
-			MemberPushTokenModel model =
-					MemberPushTokenModel.builder()
-							.memberId(memberId)
-							.pushToken(request.getPushToken())
-							.notificationProvider(provider)
-							.build();
 
-			memberPushTokenRepository.save(model);
-		}
+		MemberPushTokenModel model = memberPushTokenRepository.findByPushToken(request.getPushToken())
+			.map(existingModel -> existingModel.renew(memberId))
+			.orElseGet(() -> MemberPushTokenModel.builder()
+				.memberId(memberId)
+				.pushToken(request.getPushToken())
+				.notificationProvider(provider)
+				.lastActiveAt(LocalDateTime.now())
+				.build());
+
+		memberPushTokenRepository.save(model);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-@Slf4j
 public class NotificationTokenService
 		implements CreateMemberPushTokenUsecase,
 				DeleteAllMemberPushTokensUsecase,

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -32,7 +32,7 @@ public class NotificationTokenService
 
 		MemberPushTokenModel model =
 				memberPushTokenRepository
-						.findByPushToken(request.getPushToken())
+						.findByMemberIdAndPushToken(memberId, request.getPushToken())
 						.map(existingModel -> existingModel.renew(memberId))
 						.orElseGet(
 								() ->

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -1,8 +1,5 @@
 package com.blackcompany.eeos.notification.application.service;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.exception.DeniedDeletePushTokenException;
@@ -13,16 +10,19 @@ import com.blackcompany.eeos.notification.application.respository.MemberPushToke
 import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTokenUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
-public class NotificationTokenService implements CreateMemberPushTokenUsecase, DeleteAllMemberPushTokensUsecase,
-	DeleteMemberPushTokenUsecase {
+public class NotificationTokenService
+		implements CreateMemberPushTokenUsecase,
+				DeleteAllMemberPushTokensUsecase,
+				DeleteMemberPushTokenUsecase {
 
 	private final MemberPushTokenRepository memberPushTokenRepository;
 
@@ -31,12 +31,13 @@ public class NotificationTokenService implements CreateMemberPushTokenUsecase, D
 	public void create(Long memberId, CreateMemberPushTokenRequest request) {
 
 		NotificationProvider provider = NotificationProvider.find(request.getProvider());
-		if(memberPushTokenRepository.findByPushToken(request.getPushToken()).isEmpty()) {
-			MemberPushTokenModel model = MemberPushTokenModel.builder()
-				.memberId(memberId)
-				.pushToken(request.getPushToken())
-				.notificationProvider(provider)
-				.build();
+		if (memberPushTokenRepository.findByPushToken(request.getPushToken()).isEmpty()) {
+			MemberPushTokenModel model =
+					MemberPushTokenModel.builder()
+							.memberId(memberId)
+							.pushToken(request.getPushToken())
+							.notificationProvider(provider)
+							.build();
 
 			memberPushTokenRepository.save(model);
 		}
@@ -51,8 +52,11 @@ public class NotificationTokenService implements CreateMemberPushTokenUsecase, D
 	@Override
 	@Transactional
 	public void delete(Long memberId, DeleteMemberPushTokenRequest request) {
-		MemberPushTokenModel model = memberPushTokenRepository.findByPushToken(request.getPushToken()).orElseThrow(() -> new NotFoundPushTokenException(request.getPushToken()));
-		if(!model.getMemberId().equals(memberId)) {
+		MemberPushTokenModel model =
+				memberPushTokenRepository
+						.findByPushToken(request.getPushToken())
+						.orElseThrow(() -> new NotFoundPushTokenException(request.getPushToken()));
+		if (!model.getMemberId().equals(memberId)) {
 			throw new DeniedDeletePushTokenException();
 		}
 		memberPushTokenRepository.deleteByPushToken(request.getPushToken());

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -1,0 +1,60 @@
+package com.blackcompany.eeos.notification.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
+import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
+import com.blackcompany.eeos.notification.application.exception.DeniedDeletePushTokenException;
+import com.blackcompany.eeos.notification.application.exception.NotFoundPushTokenException;
+import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
+import com.blackcompany.eeos.notification.application.respository.MemberPushTokenRepository;
+import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTokenUsecase;
+import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
+import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class NotificationTokenService implements CreateMemberPushTokenUsecase, DeleteAllMemberPushTokensUsecase,
+	DeleteMemberPushTokenUsecase {
+
+	private final MemberPushTokenRepository memberPushTokenRepository;
+
+	@Override
+	@Transactional
+	public void create(Long memberId, CreateMemberPushTokenRequest request) {
+
+		NotificationProvider provider = NotificationProvider.find(request.getProvider());
+		if(memberPushTokenRepository.findByPushToken(request.getPushToken()).isEmpty()) {
+			MemberPushTokenModel model = MemberPushTokenModel.builder()
+				.memberId(memberId)
+				.pushToken(request.getPushToken())
+				.notificationProvider(provider)
+				.build();
+
+			memberPushTokenRepository.save(model);
+		}
+	}
+
+	@Override
+	@Transactional
+	public void deleteAllMemberPushTokens(Long memberId) {
+		memberPushTokenRepository.deleteByMemberId(memberId);
+	}
+
+	@Override
+	@Transactional
+	public void delete(Long memberId, DeleteMemberPushTokenRequest request) {
+		MemberPushTokenModel model = memberPushTokenRepository.findByPushToken(request.getPushToken()).orElseThrow(() -> new NotFoundPushTokenException(request.getPushToken()));
+		if(!model.getMemberId().equals(memberId)) {
+			throw new DeniedDeletePushTokenException();
+		}
+		memberPushTokenRepository.deleteByPushToken(request.getPushToken());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -11,7 +11,6 @@ import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTo
 import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -1,7 +1,5 @@
 package com.blackcompany.eeos.notification.application.service;
 
-import java.time.LocalDateTime;
-
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.exception.DeniedDeletePushTokenException;
@@ -12,6 +10,7 @@ import com.blackcompany.eeos.notification.application.repository.MemberPushToken
 import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTokenUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,14 +30,18 @@ public class NotificationTokenService
 	public void create(Long memberId, CreateMemberPushTokenRequest request) {
 		NotificationProvider provider = NotificationProvider.find(request.getProvider());
 
-		MemberPushTokenModel model = memberPushTokenRepository.findByPushToken(request.getPushToken())
-			.map(existingModel -> existingModel.renew(memberId))
-			.orElseGet(() -> MemberPushTokenModel.builder()
-				.memberId(memberId)
-				.pushToken(request.getPushToken())
-				.notificationProvider(provider)
-				.lastActiveAt(LocalDateTime.now())
-				.build());
+		MemberPushTokenModel model =
+				memberPushTokenRepository
+						.findByPushToken(request.getPushToken())
+						.map(existingModel -> existingModel.renew(memberId))
+						.orElseGet(
+								() ->
+										MemberPushTokenModel.builder()
+												.memberId(memberId)
+												.pushToken(request.getPushToken())
+												.notificationProvider(provider)
+												.lastActiveAt(LocalDateTime.now())
+												.build());
 
 		memberPushTokenRepository.save(model);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/CreateMemberPushTokenUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/CreateMemberPushTokenUsecase.java
@@ -1,0 +1,11 @@
+package com.blackcompany.eeos.notification.application.usecase;
+
+import org.springframework.stereotype.Component;
+
+import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
+
+@Component
+public interface CreateMemberPushTokenUsecase {
+	void create(Long memberId, CreateMemberPushTokenRequest request);
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/CreateMemberPushTokenUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/CreateMemberPushTokenUsecase.java
@@ -1,9 +1,7 @@
 package com.blackcompany.eeos.notification.application.usecase;
 
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface CreateMemberPushTokenUsecase {
 	void create(Long memberId, CreateMemberPushTokenRequest request);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/CreateMemberPushTokenUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/CreateMemberPushTokenUsecase.java
@@ -1,11 +1,9 @@
 package com.blackcompany.eeos.notification.application.usecase;
 
-import org.springframework.stereotype.Component;
-
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
+import org.springframework.stereotype.Component;
 
 @Component
 public interface CreateMemberPushTokenUsecase {
 	void create(Long memberId, CreateMemberPushTokenRequest request);
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteAllMemberPushTokensUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteAllMemberPushTokensUsecase.java
@@ -1,8 +1,5 @@
 package com.blackcompany.eeos.notification.application.usecase;
 
-import org.springframework.stereotype.Component;
-
-@Component
 public interface DeleteAllMemberPushTokensUsecase {
 	void deleteAllMemberPushTokens(Long memberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteAllMemberPushTokensUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteAllMemberPushTokensUsecase.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.notification.application.usecase;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface DeleteAllMemberPushTokensUsecase {
+	void deleteAllMemberPushTokens(Long memberId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteMemberPushTokenUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteMemberPushTokenUsecase.java
@@ -1,0 +1,10 @@
+package com.blackcompany.eeos.notification.application.usecase;
+
+import org.springframework.stereotype.Component;
+
+import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
+
+@Component
+public interface DeleteMemberPushTokenUsecase {
+	void delete(Long memberId, DeleteMemberPushTokenRequest request);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteMemberPushTokenUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteMemberPushTokenUsecase.java
@@ -1,8 +1,7 @@
 package com.blackcompany.eeos.notification.application.usecase;
 
-import org.springframework.stereotype.Component;
-
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
+import org.springframework.stereotype.Component;
 
 @Component
 public interface DeleteMemberPushTokenUsecase {

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteMemberPushTokenUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/usecase/DeleteMemberPushTokenUsecase.java
@@ -1,9 +1,7 @@
 package com.blackcompany.eeos.notification.application.usecase;
 
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface DeleteMemberPushTokenUsecase {
 	void delete(Long memberId, DeleteMemberPushTokenRequest request);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
@@ -18,6 +18,8 @@ public interface JpaMemberPushTokenRepository extends JpaRepository<MemberPushTo
 	List<MemberPushTokenEntity> findByMemberIdAndProvider(
 			Long memberId, NotificationProvider provider);
 
+	Optional<MemberPushTokenEntity> findByMemberIdAndPushToken(Long memberId, String token);
+
 	@Modifying
 	@Query("DELETE FROM MemberPushTokenEntity t WHERE t.memberId = :memberId")
 	void deleteByMemberId(@Param("memberId") Long memberId);

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
@@ -1,16 +1,13 @@
 package com.blackcompany.eeos.notification.persistence;
 
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 
 public interface JpaMemberPushTokenRepository extends JpaRepository<MemberPushTokenEntity, Long> {
 
@@ -18,7 +15,8 @@ public interface JpaMemberPushTokenRepository extends JpaRepository<MemberPushTo
 
 	List<MemberPushTokenEntity> findByMemberId(Long memberId);
 
-	List<MemberPushTokenEntity> findByMemberIdAndProvider(Long memberId, NotificationProvider provider);
+	List<MemberPushTokenEntity> findByMemberIdAndProvider(
+			Long memberId, NotificationProvider provider);
 
 	@Modifying
 	@Query("DELETE FROM MemberPushTokenEntity t WHERE t.memberId = :memberId")

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
@@ -1,0 +1,30 @@
+package com.blackcompany.eeos.notification.persistence;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
+
+public interface JpaMemberPushTokenRepository extends JpaRepository<MemberPushTokenEntity, Long> {
+
+	Optional<MemberPushTokenEntity> findByPushToken(String token);
+
+	List<MemberPushTokenEntity> findByMemberId(Long memberId);
+
+	List<MemberPushTokenEntity> findByMemberIdAndProvider(Long memberId, NotificationProvider provider);
+
+	@Modifying
+	@Query("DELETE FROM MemberPushTokenEntity t WHERE t.memberId = :memberId")
+	int deleteByMemberId(@Param("memberId") Long memberId);
+
+	void deleteByPushToken(String token);
+
+	int deleteByUpdatedDateBefore(Timestamp updatedDate);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
@@ -20,7 +20,7 @@ public interface JpaMemberPushTokenRepository extends JpaRepository<MemberPushTo
 
 	@Modifying
 	@Query("DELETE FROM MemberPushTokenEntity t WHERE t.memberId = :memberId")
-	int deleteByMemberId(@Param("memberId") Long memberId);
+	void deleteByMemberId(@Param("memberId") Long memberId);
 
 	void deleteByPushToken(String token);
 

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -2,7 +2,6 @@ package com.blackcompany.eeos.notification.persistence;
 
 import com.blackcompany.eeos.common.persistence.BaseEntity;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -43,6 +42,4 @@ public class MemberPushTokenEntity extends BaseEntity {
 
 	@Column(name = ENTITY_PREFIX + "_pushToken", nullable = false)
 	private String pushToken;
-
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -1,5 +1,7 @@
 package com.blackcompany.eeos.notification.persistence;
 
+import java.time.LocalDateTime;
+
 import com.blackcompany.eeos.common.persistence.BaseEntity;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import jakarta.persistence.Column;
@@ -42,4 +44,7 @@ public class MemberPushTokenEntity extends BaseEntity {
 
 	@Column(name = ENTITY_PREFIX + "_push_token", nullable = false, unique = true)
 	private String pushToken;
+
+	@Column(name = ENTITY_PREFIX + "_last_activate_at", nullable = false)
+	private LocalDateTime lastActiveAt;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,6 +24,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 @SuperBuilder(toBuilder = true)
+@Table(name = "member_push_token")
 public class MemberPushTokenEntity extends BaseEntity {
 
 	public static final String ENTITY_PREFIX = "member_push_token";
@@ -38,6 +40,9 @@ public class MemberPushTokenEntity extends BaseEntity {
 	@Column(name = ENTITY_PREFIX + "_provider", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private NotificationProvider provider;
+
+	@Column(name = ENTITY_PREFIX + "_pushToken", nullable = false)
+	private String pushToken;
 
 
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -40,6 +40,6 @@ public class MemberPushTokenEntity extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private NotificationProvider provider;
 
-	@Column(name = ENTITY_PREFIX + "_pushToken", nullable = false)
+	@Column(name = ENTITY_PREFIX + "_push_token", nullable = false, unique = true)
 	private String pushToken;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -1,7 +1,5 @@
 package com.blackcompany.eeos.notification.persistence;
 
-import java.time.LocalDateTime;
-
 import com.blackcompany.eeos.common.persistence.BaseEntity;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import jakarta.persistence.Column;
@@ -12,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -1,0 +1,43 @@
+package com.blackcompany.eeos.notification.persistence;
+
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@SuperBuilder(toBuilder = true)
+public class MemberPushTokenEntity extends BaseEntity {
+
+	public static final String ENTITY_PREFIX = "member_push_token";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(name = ENTITY_PREFIX + "_member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = ENTITY_PREFIX + "_provider", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private NotificationProvider provider;
+
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -43,8 +43,8 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 	}
 
 	@Override
-	public int deleteByMemberId(Long memberId) {
-		return jpaRepository.deleteByMemberId(memberId);
+	public void deleteByMemberId(Long memberId) {
+		jpaRepository.deleteByMemberId(memberId);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -30,7 +30,8 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 	}
 
 	@Override
-	public Optional<MemberPushTokenModel> findByMemberIdAndPushToken(Long memberId, String pushToken) {
+	public Optional<MemberPushTokenModel> findByMemberIdAndPushToken(
+			Long memberId, String pushToken) {
 		return jpaRepository.findByMemberIdAndPushToken(memberId, pushToken).map(converter::from);
 	}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -1,18 +1,15 @@
 package com.blackcompany.eeos.notification.persistence;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import org.springframework.stereotype.Repository;
-
 import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import com.blackcompany.eeos.notification.application.model.converter.MemberPushTokenEntityConverter;
 import com.blackcompany.eeos.notification.application.respository.MemberPushTokenRepository;
-
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,14 +30,16 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 	}
 
 	@Override
-	public List<MemberPushTokenModel> findByMemberIdAndProvider(Long memberId, NotificationProvider provider) {
-		return jpaRepository.findByMemberIdAndProvider(memberId, provider).stream().map(converter::from).toList();
+	public List<MemberPushTokenModel> findByMemberIdAndProvider(
+			Long memberId, NotificationProvider provider) {
+		return jpaRepository.findByMemberIdAndProvider(memberId, provider).stream()
+				.map(converter::from)
+				.toList();
 	}
 
 	@Override
 	public void deleteByPushToken(String pushToken) {
 		jpaRepository.deleteByPushToken(pushToken);
-
 	}
 
 	@Override
@@ -59,9 +58,5 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 		MemberPushTokenEntity memberPushTokenEntity = converter.toEntity(memberPushToken);
 		MemberPushTokenEntity saved = jpaRepository.save(memberPushTokenEntity);
 		return converter.from(saved);
-
-
-
 	}
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.blackcompany.eeos.notification.persistence;
 import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import com.blackcompany.eeos.notification.application.model.converter.MemberPushTokenEntityConverter;
-import com.blackcompany.eeos.notification.application.respository.MemberPushTokenRepository;
+import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -30,6 +30,11 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 	}
 
 	@Override
+	public Optional<MemberPushTokenModel> findByMemberIdAndPushToken(Long memberId, String pushToken) {
+		return jpaRepository.findByMemberIdAndPushToken(memberId, pushToken).map(converter::from);
+	}
+
+	@Override
 	public List<MemberPushTokenModel> findByMemberIdAndProvider(
 			Long memberId, NotificationProvider provider) {
 		return jpaRepository.findByMemberIdAndProvider(memberId, provider).stream()

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.blackcompany.eeos.notification.persistence;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
+import com.blackcompany.eeos.notification.application.model.converter.MemberPushTokenEntityConverter;
+import com.blackcompany.eeos.notification.application.respository.MemberPushTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository {
+
+	private final JpaMemberPushTokenRepository jpaRepository;
+
+	private final MemberPushTokenEntityConverter converter;
+
+	@Override
+	public Optional<MemberPushTokenModel> findByPushToken(String pushToken) {
+		return jpaRepository.findByPushToken(pushToken).map(converter::from);
+	}
+
+	@Override
+	public List<MemberPushTokenModel> findByMemberId(Long memberId) {
+		return jpaRepository.findByMemberId(memberId).stream().map(converter::from).toList();
+	}
+
+	@Override
+	public List<MemberPushTokenModel> findByMemberIdAndProvider(Long memberId, NotificationProvider provider) {
+		return jpaRepository.findByMemberIdAndProvider(memberId, provider).stream().map(converter::from).toList();
+	}
+
+	@Override
+	public void deleteByPushToken(String pushToken) {
+		jpaRepository.deleteByPushToken(pushToken);
+
+	}
+
+	@Override
+	public int deleteByMemberId(Long memberId) {
+		return jpaRepository.deleteByMemberId(memberId);
+	}
+
+	@Override
+	public int deleteByUpdatedDateBefore(LocalDateTime updatedDate) {
+		Timestamp timestamp = Timestamp.valueOf(updatedDate);
+		return jpaRepository.deleteByUpdatedDateBefore(timestamp);
+	}
+
+	@Override
+	public MemberPushTokenModel save(MemberPushTokenModel memberPushToken) {
+		MemberPushTokenEntity memberPushTokenEntity = converter.toEntity(memberPushToken);
+		MemberPushTokenEntity saved = jpaRepository.save(memberPushTokenEntity);
+		return converter.from(saved);
+
+
+
+	}
+
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/controller/MemberPushTokenController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/controller/MemberPushTokenController.java
@@ -1,12 +1,5 @@
 package com.blackcompany.eeos.notification.presentation.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.blackcompany.eeos.auth.presentation.support.Member;
 import com.blackcompany.eeos.common.presentation.response.ApiResponse;
 import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
@@ -18,9 +11,14 @@ import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTo
 import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
 import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
 import com.blackcompany.eeos.notification.presentation.docs.MemberPushTokenApi;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,22 +31,23 @@ public class MemberPushTokenController implements MemberPushTokenApi {
 
 	@Override
 	@PostMapping
-	public ApiResponse<SuccessBody<Void>> create(@Member Long memberId, @RequestBody @Valid CreateMemberPushTokenRequest request) {
+	public ApiResponse<SuccessBody<Void>> create(
+			@Member Long memberId, @RequestBody @Valid CreateMemberPushTokenRequest request) {
 		createMemberPushTokenUsecase.create(memberId, request);
 		return ApiResponseGenerator.success(HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
-
 	@Override
 	@DeleteMapping
-	public ApiResponse<SuccessBody<Void>> delete(@Member Long memberId, @RequestBody @Valid DeleteMemberPushTokenRequest request){
+	public ApiResponse<SuccessBody<Void>> delete(
+			@Member Long memberId, @RequestBody @Valid DeleteMemberPushTokenRequest request) {
 		deleteMemberPushTokenUsecase.delete(memberId, request);
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
 	}
 
 	@Override
 	@DeleteMapping("/all")
-	public ApiResponse<SuccessBody<Void>> deleteAll(@Member Long memberId){
+	public ApiResponse<SuccessBody<Void>> deleteAll(@Member Long memberId) {
 		deleteAllMemberPushTokensUsecase.deleteAllMemberPushTokens(memberId);
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/controller/MemberPushTokenController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/controller/MemberPushTokenController.java
@@ -1,0 +1,55 @@
+package com.blackcompany.eeos.notification.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.blackcompany.eeos.auth.presentation.support.Member;
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.response.MessageCode;
+import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
+import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
+import com.blackcompany.eeos.notification.application.usecase.CreateMemberPushTokenUsecase;
+import com.blackcompany.eeos.notification.application.usecase.DeleteAllMemberPushTokensUsecase;
+import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTokenUsecase;
+import com.blackcompany.eeos.notification.presentation.docs.MemberPushTokenApi;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/pushToken")
+public class MemberPushTokenController implements MemberPushTokenApi {
+
+	private final CreateMemberPushTokenUsecase createMemberPushTokenUsecase;
+	private final DeleteMemberPushTokenUsecase deleteMemberPushTokenUsecase;
+	private final DeleteAllMemberPushTokensUsecase deleteAllMemberPushTokensUsecase;
+
+	@Override
+	@PostMapping
+	public ApiResponse<SuccessBody<Void>> create(@Member Long memberId, @RequestBody @Valid CreateMemberPushTokenRequest request) {
+		createMemberPushTokenUsecase.create(memberId, request);
+		return ApiResponseGenerator.success(HttpStatus.CREATED, MessageCode.CREATE);
+	}
+
+
+	@Override
+	@DeleteMapping
+	public ApiResponse<SuccessBody<Void>> delete(@Member Long memberId, @RequestBody @Valid DeleteMemberPushTokenRequest request){
+		deleteMemberPushTokenUsecase.delete(memberId, request);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
+	}
+
+	@Override
+	@DeleteMapping("/all")
+	public ApiResponse<SuccessBody<Void>> deleteAll(@Member Long memberId){
+		deleteAllMemberPushTokensUsecase.deleteAllMemberPushTokens(memberId);
+		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/docs/MemberPushTokenApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/docs/MemberPushTokenApi.java
@@ -4,7 +4,6 @@ import com.blackcompany.eeos.common.presentation.response.ApiResponse;
 import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,12 +13,13 @@ import jakarta.validation.Valid;
 public interface MemberPushTokenApi {
 
 	@Operation(summary = "알림 토큰 등록", description = "사용자의 기기 알림 토큰을 등록한다.")
-	ApiResponse<SuccessBody<Void>> create(@Parameter(hidden = true) Long memberId, @Valid CreateMemberPushTokenRequest request);
+	ApiResponse<SuccessBody<Void>> create(
+			@Parameter(hidden = true) Long memberId, @Valid CreateMemberPushTokenRequest request);
 
 	@Operation(summary = "특정 기기 알림 토큰 삭제", description = "특정 기기 알림 토큰을 삭제한다.")
-	ApiResponse<SuccessBody<Void>> delete(@Parameter(hidden = true) Long memberId, @Valid DeleteMemberPushTokenRequest request);
+	ApiResponse<SuccessBody<Void>> delete(
+			@Parameter(hidden = true) Long memberId, @Valid DeleteMemberPushTokenRequest request);
 
 	@Operation(summary = "알림 토큰 전체 삭제", description = "특정 유저의 알림토큰을 모두 삭제한다.")
 	ApiResponse<SuccessBody<Void>> deleteAll(@Parameter(hidden = true) Long memberId);
-
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/docs/MemberPushTokenApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/presentation/docs/MemberPushTokenApi.java
@@ -1,0 +1,25 @@
+package com.blackcompany.eeos.notification.presentation.docs;
+
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
+import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "알림토큰", description = "알림 토큰 API")
+public interface MemberPushTokenApi {
+
+	@Operation(summary = "알림 토큰 등록", description = "사용자의 기기 알림 토큰을 등록한다.")
+	ApiResponse<SuccessBody<Void>> create(@Parameter(hidden = true) Long memberId, @Valid CreateMemberPushTokenRequest request);
+
+	@Operation(summary = "특정 기기 알림 토큰 삭제", description = "특정 기기 알림 토큰을 삭제한다.")
+	ApiResponse<SuccessBody<Void>> delete(@Parameter(hidden = true) Long memberId, @Valid DeleteMemberPushTokenRequest request);
+
+	@Operation(summary = "알림 토큰 전체 삭제", description = "특정 유저의 알림토큰을 모두 삭제한다.")
+	ApiResponse<SuccessBody<Void>> deleteAll(@Parameter(hidden = true) Long memberId);
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
closes #294 
## ✒️ 작업 내용
- FCM 의존성 추가
- notification 도메인 생성 및 entity 생성
- 사용자 알림 토큰 저장 및 삭제 API 구현
### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 
- 알림 서비스 구현중 알림 토큰 생성, 삭제, 전체 삭제 api 구현에 대한 pr 입니다.
- FCM에 의존적이지 않도록 네이밍, 구현하고자 했습니다.
- provider 필드로 외부 서비스에 대한 정보를 저장합니다.
- eeos에 적합한 토큰 관리 방식에 대해 고민이 많았습니다. 아래 문서대로 개발을 진행할 예정입니다. 의견주시면 감사하겠습니다 :)
https://www.notion.so/EEOS-2c2348dfe77f8076b16ae07418d1499b?source=copy_link#2d7348dfe77f80af86e3fe7b95c67a16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원별 푸시 토큰 등록, 개별 삭제, 전체 삭제 REST API 추가 (POST/DELETE /api/pushToken 등)
  * FCM 등 다수 알림 제공자 지원 및 토큰 중복 방지·갱신으로 안정적 동작 보장

* **보안**
  * 푸시 토큰 관련 API에 인증 적용

* **잡무(Chore)**
  * Firebase Admin SDK 추가 (FCM 연동 준비)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->