### PR TITLE
[FEAT] 비활성화 토큰삭제 배치 처리 구현

### DIFF
--- a/eeos/build.gradle.kts
+++ b/eeos/build.gradle.kts
@@ -67,6 +67,11 @@ dependencies {
     // Firebase Admin SDK
     implementation(libs.firebase.admin)
 
+    implementation(libs.spring.retry)
+    implementation(libs.spring.aspects)
+
+
+
 }
 
 dependencyManagement {

--- a/eeos/gradle/libs.versions.toml
+++ b/eeos/gradle/libs.versions.toml
@@ -22,6 +22,10 @@ spring-security-test="6.5.2"
 # Database
 flyway = "10.7.1"
 
+# Retry
+spring-retry = "2.0.5"
+
+
 [libraries]
 # Spring Boot
 spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web" }
@@ -60,6 +64,11 @@ lombok = { group = "org.projectlombok", name = "lombok" }
 
 # Firebase Admin SDK
 firebase-admin = { group = "com.google.firebase", name = "firebase-admin", version.ref = "firebase-admin" }
+
+# Retry
+spring-retry = { group = "org.springframework.retry", name = "spring-retry", version.ref = "spring-retry" }
+spring-aspects = { group = "org.springframework", name = "spring-aspects" }
+
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/eeos/src/main/java/com/blackcompany/eeos/config/RetryConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/RetryConfig.java
@@ -5,5 +5,4 @@ import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
 @EnableRetry
-public class RetryConfig {
-}
+public class RetryConfig {}

--- a/eeos/src/main/java/com/blackcompany/eeos/config/RetryConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.blackcompany.eeos.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
@@ -23,4 +23,6 @@ public interface MemberPushTokenRepository {
 	int deleteByUpdatedDateBefore(LocalDateTime updatedDate);
 
 	MemberPushTokenModel save(MemberPushTokenModel memberPushToken);
+
+	int deleteByLastActiveAtBefore(LocalDateTime limitDate);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
@@ -1,9 +1,7 @@
 package com.blackcompany.eeos.notification.application.scheduler;
 
-import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
 import com.blackcompany.eeos.notification.application.service.NotificationTokenService;
 import com.blackcompany.eeos.notification.application.service.SlackNotificationService;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Backoff;
@@ -11,7 +9,6 @@ import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
@@ -1,19 +1,16 @@
 package com.blackcompany.eeos.notification.application.scheduler;
 
+import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
+import com.blackcompany.eeos.notification.application.service.SlackNotificationService;
 import java.time.LocalDateTime;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
-import com.blackcompany.eeos.notification.application.service.SlackNotificationService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
@@ -27,14 +24,17 @@ public class PushTokenCleanScheduler {
 	private static final String SCHEDULER_NAME = "비활성화 토큰 삭제 스케줄러";
 
 	/*
-	* 매주 토요일 새벽 3시 90일 이상 비활성화된 푸시 토큰 삭제
-	* cron : 초 분 시 일 월 요일(6=토요일)
-	* */
+	 * 매주 토요일 새벽 3시 90일 이상 비활성화된 푸시 토큰 삭제
+	 * cron : 초 분 시 일 월 요일(6=토요일)
+	 * */
 
 	@Scheduled(cron = "0 0 3 * * 6")
 	@Transactional
-	@Retryable(maxAttempts = 3, backoff = @Backoff(delay = 2000), recover = "recoverDeleteInactiveTokens")
-	public void deleteInactiveTokens(){
+	@Retryable(
+			maxAttempts = 3,
+			backoff = @Backoff(delay = 2000),
+			recover = "recoverDeleteInactiveTokens")
+	public void deleteInactiveTokens() {
 		log.info("{} 시작", SCHEDULER_NAME);
 		LocalDateTime limitDate = LocalDateTime.now().minusDays(INACTIVE_DAYS_THRESHOLD);
 		int deleteCount = memberPushTokenRepository.deleteByLastActiveAtBefore(limitDate);
@@ -42,12 +42,12 @@ public class PushTokenCleanScheduler {
 	}
 
 	@Recover
-	public void recoverDeleteInactiveTokens(Exception e){
+	public void recoverDeleteInactiveTokens(Exception e) {
 		log.error("{} 실행 실패 - 모든 재시도 소진", SCHEDULER_NAME, e);
 
 		String errorMessage = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
 
-		if(errorMessage.length()>300){
+		if (errorMessage.length() > 300) {
 			errorMessage = errorMessage.substring(0, 300) + "...생략";
 		}
 		slackNotificationService.sendSchedulerFailureMessage(SCHEDULER_NAME, errorMessage);

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
@@ -1,0 +1,55 @@
+package com.blackcompany.eeos.notification.application.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
+import com.blackcompany.eeos.notification.application.service.SlackNotificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PushTokenCleanScheduler {
+
+	private final MemberPushTokenRepository memberPushTokenRepository;
+	private final SlackNotificationService slackNotificationService;
+
+	private static final int INACTIVE_DAYS_THRESHOLD = 90;
+	private static final String SCHEDULER_NAME = "비활성화 토큰 삭제 스케줄러";
+
+	/*
+	* 매주 토요일 새벽 3시 90일 이상 비활성화된 푸시 토큰 삭제
+	* cron : 초 분 시 일 월 요일(6=토요일)
+	* */
+
+	@Scheduled(cron = "0 0 3 * * 6")
+	@Transactional
+	@Retryable(maxAttempts = 3, backoff = @Backoff(delay = 2000), recover = "recoverDeleteInactiveTokens")
+	public void deleteInactiveTokens(){
+		log.info("{} 시작", SCHEDULER_NAME);
+		LocalDateTime limitDate = LocalDateTime.now().minusDays(INACTIVE_DAYS_THRESHOLD);
+		int deleteCount = memberPushTokenRepository.deleteByLastActiveAtBefore(limitDate);
+		log.info("{}개의 비활성 푸시 토큰 삭제 완료 (기준일: {})", deleteCount, limitDate);
+	}
+
+	@Recover
+	public void recoverDeleteInactiveTokens(Exception e){
+		log.error("{} 실행 실패 - 모든 재시도 소진", SCHEDULER_NAME, e);
+
+		String errorMessage = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+
+		if(errorMessage.length()>300){
+			errorMessage = errorMessage.substring(0, 300) + "...생략";
+		}
+		slackNotificationService.sendSchedulerFailureMessage(SCHEDULER_NAME, errorMessage);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/scheduler/PushTokenCleanScheduler.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.notification.application.scheduler;
 
 import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
+import com.blackcompany.eeos.notification.application.service.NotificationTokenService;
 import com.blackcompany.eeos.notification.application.service.SlackNotificationService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PushTokenCleanScheduler {
 
-	private final MemberPushTokenRepository memberPushTokenRepository;
 	private final SlackNotificationService slackNotificationService;
+	private final NotificationTokenService notificationTokenService;
 
 	private static final int INACTIVE_DAYS_THRESHOLD = 90;
 	private static final String SCHEDULER_NAME = "비활성화 토큰 삭제 스케줄러";
@@ -29,16 +30,14 @@ public class PushTokenCleanScheduler {
 	 * */
 
 	@Scheduled(cron = "0 0 3 * * 6")
-	@Transactional
 	@Retryable(
 			maxAttempts = 3,
 			backoff = @Backoff(delay = 2000),
 			recover = "recoverDeleteInactiveTokens")
 	public void deleteInactiveTokens() {
 		log.info("{} 시작", SCHEDULER_NAME);
-		LocalDateTime limitDate = LocalDateTime.now().minusDays(INACTIVE_DAYS_THRESHOLD);
-		int deleteCount = memberPushTokenRepository.deleteByLastActiveAtBefore(limitDate);
-		log.info("{}개의 비활성 푸시 토큰 삭제 완료 (기준일: {})", deleteCount, limitDate);
+		int deleteCount = notificationTokenService.deleteInactiveTokens();
+		log.info("{}개의 비활성화 토큰 삭제 완료", deleteCount);
 	}
 
 	@Recover

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -24,6 +24,7 @@ public class NotificationTokenService
 				DeleteMemberPushTokenUsecase {
 
 	private final MemberPushTokenRepository memberPushTokenRepository;
+	private static final int INACTIVE_DAYS_THRESHOLD = 90;
 
 	@Override
 	@Transactional
@@ -63,5 +64,11 @@ public class NotificationTokenService
 			throw new DeniedDeletePushTokenException();
 		}
 		memberPushTokenRepository.deleteByPushToken(request.getPushToken());
+	}
+
+	@Transactional
+	public int deleteInactiveTokens(){
+		LocalDateTime limitDate = LocalDateTime.now().minusDays(INACTIVE_DAYS_THRESHOLD);
+		return memberPushTokenRepository.deleteByLastActiveAtBefore(limitDate);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -67,7 +67,7 @@ public class NotificationTokenService
 	}
 
 	@Transactional
-	public int deleteInactiveTokens(){
+	public int deleteInactiveTokens() {
 		LocalDateTime limitDate = LocalDateTime.now().minusDays(INACTIVE_DAYS_THRESHOLD);
 		return memberPushTokenRepository.deleteByLastActiveAtBefore(limitDate);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/SlackNotificationService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/SlackNotificationService.java
@@ -1,0 +1,56 @@
+package com.blackcompany.eeos.notification.application.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.blackcompany.eeos.program.infra.api.slack.chat.client.SlackChatApiClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackNotificationService {
+
+	private final SlackChatApiClient slackChatApiClient;
+	private final ObjectMapper objectMapper;
+
+	@Value("${slack.bot.black-company.eeos}")
+	private String botToken;
+
+	@Value("${slack.channel.black-company.error-report}")
+	private String errorReportChannel;
+
+	public void sendSchedulerFailureMessage(String schedulerName, String errorMessage){
+		String message = String.format(
+			":rotating_light: *스케줄러 실행 실패 알림*\n\n" +
+				"*Scheduler*\n `%s`\n\n" +
+				"*Failed At*\n`%s`\n\n" +
+				"*Error Message*\n`%s`\n\n",
+			schedulerName,
+			LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+			errorMessage
+		);
+		sendMessage(message);
+	}
+
+	private void sendMessage(String text){
+		try{
+			String blocks = objectMapper.writeValueAsString(List.of(Map.of("type", "section", "text", Map.of("type","mrkdwn", "text", text))));
+
+			slackChatApiClient.post(
+				"Bearer " + botToken, errorReportChannel, blocks, "EEOS Scheduler Bot");
+
+		} catch (Exception e) {
+			log.error("Slack 알림 전송 실패", e);
+
+		}
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/SlackNotificationService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/SlackNotificationService.java
@@ -1,18 +1,15 @@
 package com.blackcompany.eeos.notification.application.service;
 
+import com.blackcompany.eeos.program.infra.api.slack.chat.client.SlackChatApiClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
-import com.blackcompany.eeos.program.infra.api.slack.chat.client.SlackChatApiClient;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -28,29 +25,30 @@ public class SlackNotificationService {
 	@Value("${slack.channel.black-company.error-report}")
 	private String errorReportChannel;
 
-	public void sendSchedulerFailureMessage(String schedulerName, String errorMessage){
-		String message = String.format(
-			":rotating_light: *스케줄러 실행 실패 알림*\n\n" +
-				"*Scheduler*\n `%s`\n\n" +
-				"*Failed At*\n`%s`\n\n" +
-				"*Error Message*\n`%s`\n\n",
-			schedulerName,
-			LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
-			errorMessage
-		);
+	public void sendSchedulerFailureMessage(String schedulerName, String errorMessage) {
+		String message =
+				String.format(
+						":rotating_light: *스케줄러 실행 실패 알림*\n\n"
+								+ "*Scheduler*\n `%s`\n\n"
+								+ "*Failed At*\n`%s`\n\n"
+								+ "*Error Message*\n`%s`\n\n",
+						schedulerName,
+						LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+						errorMessage);
 		sendMessage(message);
 	}
 
-	private void sendMessage(String text){
-		try{
-			String blocks = objectMapper.writeValueAsString(List.of(Map.of("type", "section", "text", Map.of("type","mrkdwn", "text", text))));
+	private void sendMessage(String text) {
+		try {
+			String blocks =
+					objectMapper.writeValueAsString(
+							List.of(Map.of("type", "section", "text", Map.of("type", "mrkdwn", "text", text))));
 
 			slackChatApiClient.post(
-				"Bearer " + botToken, errorReportChannel, blocks, "EEOS Scheduler Bot");
+					"Bearer " + botToken, errorReportChannel, blocks, "EEOS Scheduler Bot");
 
 		} catch (Exception e) {
 			log.error("Slack 알림 전송 실패", e);
-
 		}
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/JpaMemberPushTokenRepository.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.notification.persistence;
 
 import com.blackcompany.eeos.notification.application.model.NotificationProvider;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +28,8 @@ public interface JpaMemberPushTokenRepository extends JpaRepository<MemberPushTo
 	void deleteByPushToken(String token);
 
 	int deleteByUpdatedDateBefore(Timestamp updatedDate);
+
+	@Modifying
+	@Query("DELETE FROM MemberPushTokenEntity t where t.lastActiveAt < :limitDate")
+	int deleteByLastActiveAtBefore(@Param("limitDate") LocalDateTime limitDate);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenEntity.java
@@ -24,10 +24,10 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 @SuperBuilder(toBuilder = true)
-@Table(name = "member_push_token")
+@Table(name = "Notification_token")
 public class MemberPushTokenEntity extends BaseEntity {
 
-	public static final String ENTITY_PREFIX = "member_push_token";
+	public static final String ENTITY_PREFIX = "Notification_token";
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -65,4 +65,9 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 		MemberPushTokenEntity saved = jpaRepository.save(memberPushTokenEntity);
 		return converter.from(saved);
 	}
+
+	@Override
+	public int deleteByLastActiveAtBefore(LocalDateTime limitDate) {
+		return jpaRepository.deleteByLastActiveAtBefore(limitDate);
+	}
 }

--- a/eeos/src/main/resources/application-slack.yml
+++ b/eeos/src/main/resources/application-slack.yml
@@ -14,6 +14,8 @@ slack:
     black-company:
       slack-message-test: ${BLACK_COMPANY_TEST_CHANNEL_ID}
       notification : ${BLACK_COMPANY_NOTIFICATION_CHANNEL_ID}
+      error-report : ${BLACK_COMPANY_ERROR_REPORT_CHANNEL_ID}
+
     econovation:
       notification: ${ECONOVATION_NOTIFICATION_CHANNEL_ID}
       small_talk: ${ECONOVATION_SMALL_TALK_CHANNEL_ID}

--- a/eeos/src/main/resources/db/migration/V1.00.0.0__init_tables.sql
+++ b/eeos/src/main/resources/db/migration/V1.00.0.0__init_tables.sql
@@ -101,4 +101,3 @@ CREATE TABLE `restrict_team_building` (
 
 
 
-


### PR DESCRIPTION
## 📌 관련 이슈
closes #297 
## ✒️ 작업 내용
- lastActiveAt (최종 활동 시간)을 기준으로 90일이 지난 토큰을 삭제합니다.
- 매주 토요일 새벽 3시에 삭제를 진행합니다.
- 비활성화 토큰 삭제 실패의 경우 다음과 같이 처리하도록 구현했습니다.
   - 비활성화 토큰 삭제 스케줄링 실패 -> Retry 3회 실행 -> 슬랙 오류 보고 채널 실패 알림 전송
## 💬 REVIEWER에게 요구사항 💬 
비활성화 토큰을 주기적으로 삭제하는 스케줄링 작업에 대한 pr 입니다!
mysql 재시작 관련 docker-compose 파일 수정은 다음 pr(알림전송) 에서 함께 업로드할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비활성 푸시 토큰 자동 정리 기능 추가 — 매주 토요일 03:00에 실행되어 마지막 활동 기준 90일 경과 토큰을 삭제
  * 스케줄러 실패 시 Slack으로 알림 전송 기능 추가

* **기능 개선**
  * 스케줄러 동작에 대해 재시도 메커니즘(최대 재시도 및 백오프) 도입하여 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->