### PR TITLE
[FIX] 도커 버전 에러 해결

### DIFF
--- a/eeos/Dockerfile
+++ b/eeos/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-oracle
+FROM eclipse-temurin:21-jdk
 RUN mkdir -p /logs
 
 ENV	PROFILE defaultgi


### PR DESCRIPTION
## 📌 관련 이슈
CD 실패 이슈
## ✒️ 작업 내용
기존 dockerfile 의 베이스 이미지 버전인 `openjdk:21-oracle`가 deprecated 되어 `eclipse-temurin:21-jdk`로 수정하였습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 베이스 이미지가 업데이트되었습니다. 애플리케이션의 기능과 동작에는 영향이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->