### PR TITLE
[FIX] mysql restart, flyway 실행실패 문제 해결

### DIFF
--- a/eeos/docker-compose-dev.yml
+++ b/eeos/docker-compose-dev.yml
@@ -24,15 +24,21 @@ services:
       - "3306"
     volumes:
       - ./resources/local-develop-environment/mysql-data:/var/lib/mysql
+    restart: always
     networks:
       - internal-network
   eeos-flyway:
     container_name: eeos-flyway
     image: flyway/flyway:latest
-    command: -url=jdbc:mysql://eeos-mysql:3306/eeos?useSSL=false&allowPublicKeyRetrieval=true  -user=root -password=root migrate
+    command: [
+      "-url=jdbc:mysql://eeos-mysql:3306/eeos?useSSL=false&allowPublicKeyRetrieval=true",
+      "-user=root",
+      "-password=root",
+      "-connectRetries=60",
+      "migrate"
+    ]
     volumes:
-      - ./flyway/conf/:/flyway/conf
-      - ./flyway/sql/:/flyway/sql
+      - ./src/main/resources/db/migration/:/flyway/sql
     networks:
       - internal-network
     depends_on:
@@ -44,6 +50,7 @@ services:
       - "6379"
     environment:
       - REDIS_PASSWORD=root
+    restart: always
     networks:
       - internal-network
   eeos-backend:

--- a/eeos/docker-compose-prod.yml
+++ b/eeos/docker-compose-prod.yml
@@ -24,15 +24,21 @@ services:
       - "3306"
     volumes:
       - ./resources/local-develop-environment/mysql-data:/var/lib/mysql
+    restart: always
     networks:
       - internal-network
   eeos-flyway:
     container_name: eeos-flyway
     image: flyway/flyway:latest
-    command: -url=jdbc:mysql://eeos-mysql:3306/eeos?useSSL=false&allowPublicKeyRetrieval=true  -user=root -password=root migrate
+    command: [
+      "-url=jdbc:mysql://eeos-mysql:3306/eeos?useSSL=false&allowPublicKeyRetrieval=true",
+      "-user=root",
+      "-password=root",
+      "-connectRetries=60",
+      "migrate"
+    ]
     volumes:
-      - ./flyway/conf/:/flyway/conf
-      - ./flyway/sql/:/flyway/sql
+      - ./src/main/resources/db/migration/:/flyway/sql
     networks:
       - internal-network
     depends_on:
@@ -44,6 +50,7 @@ services:
       - "6379"
     environment:
       - REDIS_PASSWORD=root
+    restart: always
     networks:
       - internal-network
   eeos-backend:


### PR DESCRIPTION
## 📌 관련 이슈
closes #302 
## ✒️ 작업 내용
1. 주기적으로 서버가 다운되는 문제
- 비정상적으로 재부팅될때 mysql 이 정상적으로 실행되지 않는 문제가 있었습니다
-  mysql 에 restart 옵션을 추가하여 서버 재실행시 자동으로 재실행되도록 수정하였습니다.
2. flyway 실행 실패 문제
- 배포시 mysql 컨테이너보다 flyway 가 먼저 실행되어 connection refuse 문제가 발생하고 스크립트가 실행되지 않아 테이블 버저닝이 정상적으로 되지 않는 문제가 있었습니다.
- conncetRetries 옵션을 추가하여 mysql 컨테이너 실행 이후에 flyway 가 실행되도록 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * MySQL 및 Redis 서비스에 자동 재시작 기능이 추가되어 인프라 안정성이 개선되었습니다.
  * 데이터베이스 마이그레이션 설정이 최적화되었으며, 연결 재시도 메커니즘이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->