### PR TITLE
[FIX] 동일한 푸시 토큰 재등록시 409응답 처리

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DuplicatePushTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/DuplicatePushTokenException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.notification.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicatePushTokenException extends BusinessException {
+
+	private static final String FAIL_CODE = "5009";
+
+	public DuplicatePushTokenException() {
+		super(FAIL_CODE, HttpStatus.CONFLICT);
+	}
+
+	@Override
+	public String getMessage() {
+		return "이미 등록된 푸시 토큰입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundNotificationPermissionException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/exception/NotFoundNotificationPermissionException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class NotFoundNotificationPermissionException extends BusinessException {
 
-	private static final String FAIL_CODE = "5007";
+	private static final String FAIL_CODE = "5010";
 	private final String notificationPermission;
 
 	public NotFoundNotificationPermissionException(String notificationPermission) {

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/repository/MemberPushTokenRepository.java
@@ -25,6 +25,8 @@ public interface MemberPushTokenRepository {
 
 	MemberPushTokenModel save(MemberPushTokenModel memberPushToken);
 
+	MemberPushTokenModel saveAndFlush(MemberPushTokenModel memberPushToken);
+
 	int deleteByLastActiveAtBefore(LocalDateTime limitDate);
 
 	List<MemberPushTokenModel> findByMemberIdsAndNotificationPermission(

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -3,6 +3,7 @@ package com.blackcompany.eeos.notification.application.service;
 import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.dto.DeleteMemberPushTokenRequest;
 import com.blackcompany.eeos.notification.application.dto.UpdateNotificationPermissionRequest;
+import com.blackcompany.eeos.notification.application.exception.DuplicatePushTokenException;
 import com.blackcompany.eeos.notification.application.exception.NotFoundPushTokenException;
 import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
 import com.blackcompany.eeos.notification.application.model.NotificationPermission;
@@ -39,14 +40,20 @@ public class NotificationTokenService
 						.findByMemberIdAndPushToken(memberId, request.getPushToken())
 						.map(existingModel -> existingModel.renew(memberId))
 						.orElseGet(
-								() ->
-										MemberPushTokenModel.builder()
-												.memberId(memberId)
-												.pushToken(request.getPushToken())
-												.notificationProvider(provider)
-												.lastActiveAt(LocalDateTime.now())
-												.notificationPermission(NotificationPermission.ON)
-												.build());
+								() -> {
+									if (memberPushTokenRepository
+											.findByPushToken(request.getPushToken())
+											.isPresent()) {
+										throw new DuplicatePushTokenException();
+									}
+									return MemberPushTokenModel.builder()
+											.memberId(memberId)
+											.pushToken(request.getPushToken())
+											.notificationProvider(provider)
+											.lastActiveAt(LocalDateTime.now())
+											.notificationPermission(NotificationPermission.ON)
+											.build();
+								});
 
 		memberPushTokenRepository.save(model);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/application/service/NotificationTokenService.java
@@ -15,6 +15,7 @@ import com.blackcompany.eeos.notification.application.usecase.DeleteMemberPushTo
 import com.blackcompany.eeos.notification.application.usecase.UpdateNotificationPermissionUsecase;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,22 +41,20 @@ public class NotificationTokenService
 						.findByMemberIdAndPushToken(memberId, request.getPushToken())
 						.map(existingModel -> existingModel.renew(memberId))
 						.orElseGet(
-								() -> {
-									if (memberPushTokenRepository
-											.findByPushToken(request.getPushToken())
-											.isPresent()) {
-										throw new DuplicatePushTokenException();
-									}
-									return MemberPushTokenModel.builder()
-											.memberId(memberId)
-											.pushToken(request.getPushToken())
-											.notificationProvider(provider)
-											.lastActiveAt(LocalDateTime.now())
-											.notificationPermission(NotificationPermission.ON)
-											.build();
-								});
+								() ->
+										MemberPushTokenModel.builder()
+												.memberId(memberId)
+												.pushToken(request.getPushToken())
+												.notificationProvider(provider)
+												.lastActiveAt(LocalDateTime.now())
+												.notificationPermission(NotificationPermission.ON)
+												.build());
 
-		memberPushTokenRepository.save(model);
+		try {
+			memberPushTokenRepository.saveAndFlush(model);
+		} catch (DataIntegrityViolationException e) {
+			throw new DuplicatePushTokenException();
+		}
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/persistence/MemberPushTokenRepositoryImpl.java
@@ -68,6 +68,13 @@ public class MemberPushTokenRepositoryImpl implements MemberPushTokenRepository 
 	}
 
 	@Override
+	public MemberPushTokenModel saveAndFlush(MemberPushTokenModel memberPushToken) {
+		NotificationTokenEntity notificationTokenEntity = converter.toEntity(memberPushToken);
+		NotificationTokenEntity saved = jpaRepository.saveAndFlush(notificationTokenEntity);
+		return converter.from(saved);
+	}
+
+	@Override
 	public int deleteByLastActiveAtBefore(LocalDateTime limitDate) {
 		return jpaRepository.deleteByLastActiveAtBefore(limitDate);
 	}

--- a/eeos/src/test/java/com/blackcompany/eeos/notification/application/service/NotificationTokenServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/notification/application/service/NotificationTokenServiceTest.java
@@ -58,10 +58,7 @@ class NotificationTokenServiceTest {
 		// given
 		Long memberId = 1L;
 		CreateMemberPushTokenRequest request =
-				CreateMemberPushTokenRequest.builder()
-						.pushToken("existing-token")
-						.provider("FCM")
-						.build();
+				CreateMemberPushTokenRequest.builder().pushToken("existing-token").provider("FCM").build();
 
 		MemberPushTokenModel existingModel = createTokenModel(memberId, "existing-token");
 		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberId, "existing-token"))
@@ -82,10 +79,7 @@ class NotificationTokenServiceTest {
 		// given
 		Long memberId = 1L;
 		CreateMemberPushTokenRequest request =
-				CreateMemberPushTokenRequest.builder()
-						.pushToken("duplicate-token")
-						.provider("FCM")
-						.build();
+				CreateMemberPushTokenRequest.builder().pushToken("duplicate-token").provider("FCM").build();
 
 		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberId, "duplicate-token"))
 				.thenReturn(Optional.empty());

--- a/eeos/src/test/java/com/blackcompany/eeos/notification/application/service/NotificationTokenServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/notification/application/service/NotificationTokenServiceTest.java
@@ -1,0 +1,133 @@
+package com.blackcompany.eeos.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.notification.application.dto.CreateMemberPushTokenRequest;
+import com.blackcompany.eeos.notification.application.exception.DuplicatePushTokenException;
+import com.blackcompany.eeos.notification.application.model.MemberPushTokenModel;
+import com.blackcompany.eeos.notification.application.model.NotificationPermission;
+import com.blackcompany.eeos.notification.application.model.NotificationProvider;
+import com.blackcompany.eeos.notification.application.repository.MemberPushTokenRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationTokenServiceTest {
+
+	@Mock private MemberPushTokenRepository memberPushTokenRepository;
+
+	private NotificationTokenService notificationTokenService;
+
+	@BeforeEach
+	void setUp() {
+		notificationTokenService = new NotificationTokenService(memberPushTokenRepository);
+	}
+
+	@Test
+	@DisplayName("새로운 푸시 토큰을 성공적으로 생성한다")
+	void create_new_push_token_success() {
+		// given
+		Long memberId = 1L;
+		CreateMemberPushTokenRequest request =
+				CreateMemberPushTokenRequest.builder().pushToken("new-token").provider("FCM").build();
+
+		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberId, "new-token"))
+				.thenReturn(Optional.empty());
+		when(memberPushTokenRepository.saveAndFlush(any(MemberPushTokenModel.class)))
+				.thenReturn(createTokenModel(memberId, "new-token"));
+
+		// when
+		notificationTokenService.create(memberId, request);
+
+		// then
+		verify(memberPushTokenRepository).saveAndFlush(any(MemberPushTokenModel.class));
+	}
+
+	@Test
+	@DisplayName("동일한 회원의 기존 토큰이 있으면 갱신한다")
+	void create_renews_existing_token_for_same_member() {
+		// given
+		Long memberId = 1L;
+		CreateMemberPushTokenRequest request =
+				CreateMemberPushTokenRequest.builder()
+						.pushToken("existing-token")
+						.provider("FCM")
+						.build();
+
+		MemberPushTokenModel existingModel = createTokenModel(memberId, "existing-token");
+		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberId, "existing-token"))
+				.thenReturn(Optional.of(existingModel));
+		when(memberPushTokenRepository.saveAndFlush(any(MemberPushTokenModel.class)))
+				.thenReturn(existingModel);
+
+		// when
+		notificationTokenService.create(memberId, request);
+
+		// then
+		verify(memberPushTokenRepository).saveAndFlush(any(MemberPushTokenModel.class));
+	}
+
+	@Test
+	@DisplayName("다른 회원이 이미 등록한 토큰으로 생성 시도하면 DuplicatePushTokenException이 발생한다")
+	void create_throws_exception_when_token_belongs_to_another_member() {
+		// given
+		Long memberId = 1L;
+		CreateMemberPushTokenRequest request =
+				CreateMemberPushTokenRequest.builder()
+						.pushToken("duplicate-token")
+						.provider("FCM")
+						.build();
+
+		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberId, "duplicate-token"))
+				.thenReturn(Optional.empty());
+		when(memberPushTokenRepository.saveAndFlush(any(MemberPushTokenModel.class)))
+				.thenThrow(new DataIntegrityViolationException("Duplicate entry"));
+
+		// when & then
+		assertThatThrownBy(() -> notificationTokenService.create(memberId, request))
+				.isInstanceOf(DuplicatePushTokenException.class);
+	}
+
+	@Test
+	@DisplayName("동시에 같은 토큰으로 생성 시도 시 TOCTOU 문제가 발생하지 않고 예외가 발생한다")
+	void create_handles_concurrent_duplicate_token_creation() {
+		// given
+		Long memberIdA = 1L;
+		Long memberIdB = 2L;
+		String sameToken = "same-token";
+
+		CreateMemberPushTokenRequest requestA =
+				CreateMemberPushTokenRequest.builder().pushToken(sameToken).provider("FCM").build();
+
+		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberIdA, sameToken))
+				.thenReturn(Optional.empty());
+		when(memberPushTokenRepository.saveAndFlush(any(MemberPushTokenModel.class)))
+				.thenThrow(new DataIntegrityViolationException("Duplicate entry"));
+
+		// when & then
+		assertThatThrownBy(() -> notificationTokenService.create(memberIdA, requestA))
+				.isInstanceOf(DuplicatePushTokenException.class);
+
+		verify(memberPushTokenRepository).saveAndFlush(any(MemberPushTokenModel.class));
+	}
+
+	private MemberPushTokenModel createTokenModel(Long memberId, String pushToken) {
+		return MemberPushTokenModel.builder()
+				.id(1L)
+				.memberId(memberId)
+				.pushToken(pushToken)
+				.notificationProvider(NotificationProvider.FCM)
+				.notificationPermission(NotificationPermission.ON)
+				.lastActiveAt(LocalDateTime.now())
+				.build();
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/notification/application/service/NotificationTokenServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/notification/application/service/NotificationTokenServiceTest.java
@@ -74,8 +74,8 @@ class NotificationTokenServiceTest {
 	}
 
 	@Test
-	@DisplayName("다른 회원이 이미 등록한 토큰으로 생성 시도하면 DuplicatePushTokenException이 발생한다")
-	void create_throws_exception_when_token_belongs_to_another_member() {
+	@DisplayName("DB unique 제약 위반 시 DuplicatePushTokenException으로 변환된다")
+	void create_converts_DataIntegrityViolationException_to_DuplicatePushTokenException() {
 		// given
 		Long memberId = 1L;
 		CreateMemberPushTokenRequest request =
@@ -89,29 +89,6 @@ class NotificationTokenServiceTest {
 		// when & then
 		assertThatThrownBy(() -> notificationTokenService.create(memberId, request))
 				.isInstanceOf(DuplicatePushTokenException.class);
-	}
-
-	@Test
-	@DisplayName("동시에 같은 토큰으로 생성 시도 시 TOCTOU 문제가 발생하지 않고 예외가 발생한다")
-	void create_handles_concurrent_duplicate_token_creation() {
-		// given
-		Long memberIdA = 1L;
-		Long memberIdB = 2L;
-		String sameToken = "same-token";
-
-		CreateMemberPushTokenRequest requestA =
-				CreateMemberPushTokenRequest.builder().pushToken(sameToken).provider("FCM").build();
-
-		when(memberPushTokenRepository.findByMemberIdAndPushToken(memberIdA, sameToken))
-				.thenReturn(Optional.empty());
-		when(memberPushTokenRepository.saveAndFlush(any(MemberPushTokenModel.class)))
-				.thenThrow(new DataIntegrityViolationException("Duplicate entry"));
-
-		// when & then
-		assertThatThrownBy(() -> notificationTokenService.create(memberIdA, requestA))
-				.isInstanceOf(DuplicatePushTokenException.class);
-
-		verify(memberPushTokenRepository).saveAndFlush(any(MemberPushTokenModel.class));
 	}
 
 	private MemberPushTokenModel createTokenModel(Long memberId, String pushToken) {


### PR DESCRIPTION
## 📌 관련 이슈
closes #308 
## ✒️ 작업 내용
각자 다른 사용자가 한개의 기기로 로그인, 알림토큰 발급시 500에러가 발생했고, 이를 409 에러로 처리하도록 수정했습니다.

**에러 시나리오 (다른 유저, 같은 기기):**

1. 유저 A가 기기 X로 로그인 → 토큰 등록 (memberId=A, pushToken=X)
2. 유저 A 로그아웃, 유저 B가 같은 기기 X로 로그인
3. indByMemberIdAndPushToken(B, X) → 못 찾음 (A로 등록되어 있으니까)
4. 새로 INSERT 시도 → pushToken unique 제약조건 위반 → 500 에러

**변경사항**
- DuplicatePushTokenException 추가
- tokenService create 로직 수정 
  - memberId, pushToken 으로 기존 토큰 조회
  - 이후 memberId로 기존 토큰 조회 -> 토큰 있는 경우(다른 회원의 기기로 로그인한 경우) dulicatePushTokenException 발생

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 푸시 토큰 중복 등록 감지 및 명확한 충돌 처리 추가 (중복 시 사용자용 한글 오류 메시지 제공)

* **버그 수정**
  * 중복 푸시 토큰 발생 시 일관된 충돌 응답 반환
  * 알림 권한 관련 오류 응답 코드 정비

* **테스트**
  * 생성·갱신·중복 및 동시성 시나리오를 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->