### PR TITLE
[FEAT] EEOS 회원가입 API 추가 (id/password/기수/성함)

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/request/EeosSignUpCommand.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/request/EeosSignUpCommand.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.auth.application.dto.request;
+
+import com.blackcompany.eeos.common.support.dto.AbstractDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EeosSignUpCommand implements AbstractDto {
+
+	private String loginId;
+	private String password;
+	private Integer generation;
+	private String name;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/DuplicateLoginIdException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/DuplicateLoginIdException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateLoginIdException extends BusinessException {
+
+	private static final String FAIL_CODE = "4009";
+
+	public DuplicateLoginIdException() {
+		super(FAIL_CODE, HttpStatus.CONFLICT);
+	}
+
+	@Override
+	public String getMessage() {
+		return "이미 사용 중인 아이디입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/repository/AccountRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/repository/AccountRepository.java
@@ -5,4 +5,8 @@ import com.blackcompany.eeos.auth.application.model.AccountModel;
 public interface AccountRepository {
 
 	AccountModel findByLoginId(String loginId);
+
+	AccountModel save(AccountModel model);
+
+	boolean existsByLoginId(String loginId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -15,11 +15,13 @@ import com.blackcompany.eeos.auth.application.usecase.EeosSignUpUseCase;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,8 +42,7 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 		saveAccount(command.getLoginId(), command.getPassword(), savedMember.getMemberId());
 		saveAuthority(savedMember.getMemberId());
 
-		Set<String> roles = getRoles(savedMember.getMemberId());
-		return tokenGenerator.execute(savedMember.getMemberId(), roles);
+		return tokenGenerator.execute(savedMember.getMemberId(), Set.of(Role.ROLE_USER.name()));
 	}
 
 	private void validateDuplicateLoginId(String loginId) {
@@ -67,17 +68,15 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 						.password(encryptedPassword)
 						.memberId(memberId)
 						.build();
-		accountRepository.save(accountModel);
+		try {
+			accountRepository.save(accountModel);
+		} catch (DataIntegrityViolationException e) {
+			log.warn("loginId 중복 저장 시도: {}", loginId);
+			throw new DuplicateLoginIdException();
+		}
 	}
 
 	private void saveAuthority(Long memberId) {
 		authorityRepository.save(AuthorityModel.create(memberId, Role.ROLE_USER));
-	}
-
-	private Set<String> getRoles(Long memberId) {
-		return authorityRepository.findByMemberId(memberId).stream()
-				.map(AuthorityModel::getRole)
-				.map(Role::name)
-				.collect(Collectors.toSet());
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -68,7 +68,7 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 		try {
 			accountRepository.save(accountModel);
 		} catch (DataIntegrityViolationException e) {
-			log.warn("loginId 중복 저장 시도: {}", loginId);
+			log.warn("loginId 중복 저장 시도 발생");
 			throw new DuplicateLoginIdException();
 		}
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -1,0 +1,83 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+import com.blackcompany.eeos.auth.application.exception.DuplicateLoginIdException;
+import com.blackcompany.eeos.auth.application.model.AccountModel;
+import com.blackcompany.eeos.auth.application.model.AuthorityModel;
+import com.blackcompany.eeos.auth.application.model.Role;
+import com.blackcompany.eeos.auth.application.repository.AccountRepository;
+import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
+import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
+import com.blackcompany.eeos.auth.application.support.EncryptHelper;
+import com.blackcompany.eeos.auth.application.usecase.EeosSignUpUseCase;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EeosSignUpService implements EeosSignUpUseCase {
+
+	private final MemberRepository memberRepository;
+	private final AccountRepository accountRepository;
+	private final AuthorityRepository authorityRepository;
+	private final EncryptHelper encryptHelper;
+	private final AuthenticationTokenGenerator tokenGenerator;
+
+	@Override
+	@Transactional
+	public TokenModel signUp(EeosSignUpCommand command) {
+		validateDuplicateLoginId(command.getLoginId());
+
+		MemberModel savedMember = saveMember(command.getName(), command.getGeneration());
+		saveAccount(command.getLoginId(), command.getPassword(), savedMember.getMemberId());
+		saveAuthority(savedMember.getMemberId());
+
+		Set<String> roles = getRoles(savedMember.getMemberId());
+		return tokenGenerator.execute(savedMember.getMemberId(), roles);
+	}
+
+	private void validateDuplicateLoginId(String loginId) {
+		if (accountRepository.existsByLoginId(loginId)) {
+			throw new DuplicateLoginIdException();
+		}
+	}
+
+	private MemberModel saveMember(String name, Integer generation) {
+		MemberModel memberModel =
+				MemberModel.builder()
+						.name(name, generation)
+						.oauthServerType(OauthServerType.EEOS)
+						.build();
+		return memberRepository.save(memberModel);
+	}
+
+	private void saveAccount(String loginId, String rawPassword, Long memberId) {
+		String encryptedPassword = encryptHelper.encrypt(rawPassword);
+		AccountModel accountModel =
+				AccountModel.builder()
+						.loginId(loginId)
+						.password(encryptedPassword)
+						.memberId(memberId)
+						.build();
+		accountRepository.save(accountModel);
+	}
+
+	private void saveAuthority(Long memberId) {
+		authorityRepository.save(AuthorityModel.create(memberId, Role.ROLE_USER));
+	}
+
+	private Set<String> getRoles(Long memberId) {
+		return authorityRepository.findByMemberId(memberId).stream()
+				.map(AuthorityModel::getRole)
+				.map(Role::name)
+				.collect(Collectors.toSet());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -53,10 +53,7 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 
 	private MemberModel saveMember(String name, Integer generation) {
 		MemberModel memberModel =
-				MemberModel.builder()
-						.name(name, generation)
-						.oauthServerType(OauthServerType.EEOS)
-						.build();
+				MemberModel.builder().name(name, generation).oauthServerType(OauthServerType.EEOS).build();
 		return memberRepository.save(memberModel);
 	}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/usecase/EeosSignUpUseCase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/usecase/EeosSignUpUseCase.java
@@ -1,0 +1,8 @@
+package com.blackcompany.eeos.auth.application.usecase;
+
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+
+public interface EeosSignUpUseCase {
+	TokenModel signUp(EeosSignUpCommand command);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountJpaRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountJpaRepository.java
@@ -12,4 +12,6 @@ public interface AccountJpaRepository extends JpaRepository<AccountEntity, Long>
 
 	@Query("SELECT a FROM AccountEntity a WHERE a.loginId=:loginId")
 	Optional<AccountEntity> findByLoginId(@Param("loginId") String loginId);
+
+	boolean existsByLoginId(String loginId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.auth.persistence.account;
 
 import com.blackcompany.eeos.auth.application.exception.NotFoundAccountException;
+import com.blackcompany.eeos.auth.application.model.AccountEntityConverter;
 import com.blackcompany.eeos.auth.application.model.AccountModel;
 import com.blackcompany.eeos.auth.application.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 public class AccountRepositoryImpl implements AccountRepository {
 
 	private final AccountJpaRepository jpaRepository;
+	private final AccountEntityConverter converter;
 
 	@Override
 	public AccountModel findByLoginId(String loginId) {
@@ -20,11 +22,18 @@ public class AccountRepositoryImpl implements AccountRepository {
 						.orElseThrow(
 								NotFoundAccountException
 										::new); // TODO: 이 예외는 application 계층의 예외이므로, persistence 영역의 예외로 변경
-		return AccountModel.builder()
-				.id(entity.getId())
-				.loginId(entity.getLoginId())
-				.password(entity.getPassWd())
-				.memberId(entity.getMemberId())
-				.build();
+		return converter.from(entity);
+	}
+
+	@Override
+	public AccountModel save(AccountModel model) {
+		AccountEntity entity = converter.toEntity(model);
+		AccountEntity saved = jpaRepository.save(entity);
+		return converter.from(saved);
+	}
+
+	@Override
+	public boolean existsByLoginId(String loginId) {
+		return jpaRepository.existsByLoginId(loginId);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -4,11 +4,13 @@ import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
 import com.blackcompany.eeos.auth.application.dto.request.AdditionalInfoApplicationCommand;
 import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
+import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
 import com.blackcompany.eeos.auth.application.dto.request.OAuthLoginRequestCommand;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
 import com.blackcompany.eeos.auth.application.usecase.*;
 import com.blackcompany.eeos.auth.presentation.docs.AuthApi;
 import com.blackcompany.eeos.auth.presentation.dto.AdditionalInfoRequest;
+import com.blackcompany.eeos.auth.presentation.dto.EeosSignUpRequest;
 import com.blackcompany.eeos.auth.presentation.support.AuthConstants;
 import com.blackcompany.eeos.auth.presentation.support.Member;
 import com.blackcompany.eeos.auth.presentation.support.TokenExtractor;
@@ -44,6 +46,7 @@ public class AuthController implements AuthApi {
 	private final LogOutUsecase logOutUsecase;
 	private final WithDrawUsecase withDrawUsecase;
 	private final OAuthSignUpUseCase oAuthSignUpUseCase;
+	private final EeosSignUpUseCase eeosSignUpUseCase;
 
 	public AuthController(
 			LoginUsecase loginUsecase,
@@ -53,7 +56,8 @@ public class AuthController implements AuthApi {
 			CookieManager cookieManager,
 			LogOutUsecase logOutUsecase,
 			WithDrawUsecase withDrawUsecase,
-			OAuthSignUpUseCase oAuthSignUpUseCase) {
+			OAuthSignUpUseCase oAuthSignUpUseCase,
+			EeosSignUpUseCase eeosSignUpUseCase) {
 		this.loginUsecase = loginUsecase;
 		this.reissueUsecase = reissueUsecase;
 		this.tokenExtractor = tokenExtractor;
@@ -62,6 +66,7 @@ public class AuthController implements AuthApi {
 		this.logOutUsecase = logOutUsecase;
 		this.withDrawUsecase = withDrawUsecase;
 		this.oAuthSignUpUseCase = oAuthSignUpUseCase;
+		this.eeosSignUpUseCase = eeosSignUpUseCase;
 	}
 
 	@Override
@@ -128,6 +133,17 @@ public class AuthController implements AuthApi {
 		deleteTokenResponse(httpResponse);
 
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
+	}
+
+	@PostMapping("/signup")
+	public ApiResponse<SuccessBody<TokenResponse>> signUp(
+			@Valid @RequestBody EeosSignUpRequest request, HttpServletResponse httpResponse) {
+		EeosSignUpCommand command =
+				new EeosSignUpCommand(
+						request.getId(), request.getPassword(), request.getGeneration(), request.getName());
+		TokenModel tokenModel = eeosSignUpUseCase.signUp(command);
+		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
 	@PostMapping("/login/additional-info")

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -135,6 +135,7 @@ public class AuthController implements AuthApi {
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
 	}
 
+	@Override
 	@PostMapping("/signup")
 	public ApiResponse<SuccessBody<TokenResponse>> signUp(
 			@Valid @RequestBody EeosSignUpRequest request, HttpServletResponse httpResponse) {

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.auth.presentation.docs;
 
 import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
+import com.blackcompany.eeos.auth.presentation.dto.EeosSignUpRequest;
 import com.blackcompany.eeos.auth.presentation.support.Member;
 import com.blackcompany.eeos.common.presentation.response.ApiResponse;
 import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +33,12 @@ public interface AuthApi {
 	@Operation(summary = "일반 로그인", description = "사용자가 id와 password를 이용하여 로그인한다.")
 	ApiResponse<SuccessBody<TokenResponse>> login(
 			@Parameter(description = "로그인 요청 정보", required = true) @RequestBody EEOSLoginRequest request,
+			HttpServletResponse httpResponse);
+
+	@Operation(summary = "회원가입", description = "id, password, 기수, 성함으로 회원가입하고 토큰을 반환한다.")
+	ApiResponse<SuccessBody<TokenResponse>> signUp(
+			@Parameter(description = "회원가입 요청 정보", required = true) @Valid @RequestBody
+					EeosSignUpRequest request,
 			HttpServletResponse httpResponse);
 
 	@Operation(

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
@@ -29,5 +29,6 @@ public class EeosSignUpRequest {
 	private Integer generation;
 
 	@NotBlank(message = "성함은 필수 입력값입니다")
+	@Size(max = 50, message = "성함은 50자 이하여야 합니다")
 	private String name;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
@@ -1,0 +1,31 @@
+package com.blackcompany.eeos.auth.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EeosSignUpRequest {
+
+	@NotBlank(message = "아이디는 필수 입력값입니다")
+	private String id;
+
+	@NotBlank(message = "비밀번호는 필수 입력값입니다")
+	@Pattern(
+			regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
+			message = "비밀번호는 8~20자이며, 영문과 숫자를 포함해야 합니다")
+	private String password;
+
+	@NotNull(message = "기수는 필수 입력값입니다")
+	@Min(value = 1, message = "기수는 1 이상이어야 합니다")
+	private Integer generation;
+
+	@NotBlank(message = "성함은 필수 입력값입니다")
+	private String name;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class EeosSignUpRequest {
 
 	@NotBlank(message = "아이디는 필수 입력값입니다")
+	@Size(max = 50, message = "아이디는 50자 이하여야 합니다")
 	private String id;
 
 	@NotBlank(message = "비밀번호는 필수 입력값입니다")

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
@@ -53,6 +53,7 @@ public class SecurityFilterChainConfig {
 							.requestMatchers("/api/auth/login/additional-info")
 							.requestMatchers(HttpMethod.POST, "/api/auth/login/**")
 							.requestMatchers(HttpMethod.POST, "/api/auth/login")
+							.requestMatchers(HttpMethod.POST, "/api/auth/signup")
 							.requestMatchers("/api/guest/**")
 							.requestMatchers("/api/health-check");
 				});

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosLoginServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosLoginServiceTest.java
@@ -9,7 +9,6 @@ import com.blackcompany.eeos.auth.application.exception.NotFoundAccountException
 import com.blackcompany.eeos.auth.application.model.AccountModel;
 import com.blackcompany.eeos.auth.application.repository.AccountRepository;
 import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
-import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
@@ -24,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class EeosLoginServiceTest {
 
 	@Mock MemberRepository memberRepository;
-	@Mock OAuthMemberRepository oAuthMemberRepository;
 	@Mock AccountRepository accountRepository;
 	@Mock AuthorityRepository authorityRepository;
 	@Mock EncryptHelper encryptHelper;

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosLoginServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosLoginServiceTest.java
@@ -1,0 +1,104 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
+import com.blackcompany.eeos.auth.application.exception.NotFoundAccountException;
+import com.blackcompany.eeos.auth.application.model.AccountModel;
+import com.blackcompany.eeos.auth.application.repository.AccountRepository;
+import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
+import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
+import com.blackcompany.eeos.auth.application.support.EncryptHelper;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EeosLoginServiceTest {
+
+	@Mock MemberRepository memberRepository;
+	@Mock OAuthMemberRepository oAuthMemberRepository;
+	@Mock AccountRepository accountRepository;
+	@Mock AuthorityRepository authorityRepository;
+	@Mock EncryptHelper encryptHelper;
+
+	@InjectMocks AuthService authService;
+
+	@Test
+	@DisplayName("올바른 id/password로 로그인하면 MemberModel을 반환한다.")
+	void login_with_valid_credentials() {
+		// given
+		Long memberId = 1L;
+		String loginId = "testId";
+		String rawPassword = "password123";
+		String encryptedPassword = "encrypted_password123";
+
+		AccountModel accountModel =
+				AccountModel.builder()
+						.id(1L)
+						.loginId(loginId)
+						.password(encryptedPassword)
+						.memberId(memberId)
+						.build();
+
+		MemberModel memberModel =
+				MemberModel.builder()
+						.id(memberId)
+						.name("15기 홍길동")
+						.oauthServerType(OauthServerType.EEOS)
+						.build();
+
+		when(accountRepository.findByLoginId(loginId)).thenReturn(accountModel);
+		when(encryptHelper.isMatch(rawPassword, encryptedPassword)).thenReturn(true);
+		when(memberRepository.findById(memberId)).thenReturn(memberModel);
+
+		// when
+		MemberModel result = authService.authenticate(loginId, rawPassword);
+
+		// then
+		assertEquals(memberId, result.getMemberId());
+	}
+
+	@Test
+	@DisplayName("비밀번호가 틀리면 NotFoundAccountException이 발생한다.")
+	void login_with_wrong_password_throws_exception() {
+		// given
+		String loginId = "testId";
+		String rawPassword = "wrongPassword";
+		String encryptedPassword = "encrypted_password123";
+
+		AccountModel accountModel =
+				AccountModel.builder()
+						.id(1L)
+						.loginId(loginId)
+						.password(encryptedPassword)
+						.memberId(1L)
+						.build();
+
+		when(accountRepository.findByLoginId(loginId)).thenReturn(accountModel);
+		when(encryptHelper.isMatch(rawPassword, encryptedPassword)).thenReturn(false);
+
+		// when & then
+		assertThrows(NotFoundAccountException.class, () -> authService.authenticate(loginId, rawPassword));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 id로 로그인하면 NotFoundAccountException이 발생한다.")
+	void login_with_nonexistent_id_throws_exception() {
+		// given
+		String loginId = "nonExistentId";
+		String rawPassword = "password123";
+
+		when(accountRepository.findByLoginId(loginId)).thenThrow(new NotFoundAccountException());
+
+		// when & then
+		assertThrows(NotFoundAccountException.class, () -> authService.authenticate(loginId, rawPassword));
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosLoginServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosLoginServiceTest.java
@@ -84,7 +84,8 @@ class EeosLoginServiceTest {
 		when(encryptHelper.isMatch(rawPassword, encryptedPassword)).thenReturn(false);
 
 		// when & then
-		assertThrows(NotFoundAccountException.class, () -> authService.authenticate(loginId, rawPassword));
+		assertThrows(
+				NotFoundAccountException.class, () -> authService.authenticate(loginId, rawPassword));
 	}
 
 	@Test
@@ -97,6 +98,7 @@ class EeosLoginServiceTest {
 		when(accountRepository.findByLoginId(loginId)).thenThrow(new NotFoundAccountException());
 
 		// when & then
-		assertThrows(NotFoundAccountException.class, () -> authService.authenticate(loginId, rawPassword));
+		assertThrows(
+				NotFoundAccountException.class, () -> authService.authenticate(loginId, rawPassword));
 	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -50,10 +50,8 @@ class EeosSignUpServiceTest {
 		EeosSignUpCommand command = new EeosSignUpCommand(loginId, rawPassword, generation, name);
 
 		MemberModel savedMember = MemberModel.builder().id(memberId).name(name, generation).build();
-		TokenModel expectedToken = TokenModel.builder()
-				.accessToken("access_token")
-				.refreshToken("refresh_token")
-				.build();
+		TokenModel expectedToken =
+				TokenModel.builder().accessToken("access_token").refreshToken("refresh_token").build();
 
 		when(accountRepository.existsByLoginId(loginId)).thenReturn(false);
 		when(encryptHelper.encrypt(rawPassword)).thenReturn(encryptedPassword);

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -1,0 +1,91 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+import com.blackcompany.eeos.auth.application.exception.DuplicateLoginIdException;
+import com.blackcompany.eeos.auth.application.model.AuthorityModel;
+import com.blackcompany.eeos.auth.application.model.Role;
+import com.blackcompany.eeos.auth.application.repository.AccountRepository;
+import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
+import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
+import com.blackcompany.eeos.auth.application.support.EncryptHelper;
+import com.blackcompany.eeos.auth.fixture.FakeAuthority;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EeosSignUpServiceTest {
+
+	@Mock MemberRepository memberRepository;
+	@Mock AccountRepository accountRepository;
+	@Mock AuthorityRepository authorityRepository;
+	@Mock EncryptHelper encryptHelper;
+	@Mock AuthenticationTokenGenerator tokenGenerator;
+
+	@InjectMocks EeosSignUpService eeosSignUpService;
+
+	@Test
+	@DisplayName("정상적인 회원가입 요청이 들어오면 토큰을 반환한다.")
+	void signUp_success() {
+		// given
+		Long memberId = 1L;
+		String loginId = "testId";
+		String rawPassword = "password123";
+		String encryptedPassword = "encrypted_password123";
+		String name = "홍길동";
+		Integer generation = 15;
+
+		EeosSignUpCommand command = new EeosSignUpCommand(loginId, rawPassword, generation, name);
+
+		MemberModel savedMember = MemberModel.builder().id(memberId).name(name, generation).build();
+		Set<AuthorityModel> authorities = Set.of(FakeAuthority.authorityModel(1L, memberId, Role.ROLE_USER));
+		TokenModel expectedToken = TokenModel.builder()
+				.accessToken("access_token")
+				.refreshToken("refresh_token")
+				.build();
+
+		when(accountRepository.existsByLoginId(loginId)).thenReturn(false);
+		when(encryptHelper.encrypt(rawPassword)).thenReturn(encryptedPassword);
+		when(memberRepository.save(any(MemberModel.class))).thenReturn(savedMember);
+		when(authorityRepository.findByMemberId(memberId)).thenReturn(authorities);
+		when(tokenGenerator.execute(any(Long.class), any(Set.class))).thenReturn(expectedToken);
+
+		// when
+		TokenModel result = eeosSignUpService.signUp(command);
+
+		// then
+		verify(accountRepository).save(any());
+		verify(authorityRepository).save(any());
+		verify(tokenGenerator).execute(any(Long.class), any(Set.class));
+	}
+
+	@Test
+	@DisplayName("이미 사용 중인 아이디로 회원가입하면 DuplicateLoginIdException이 발생한다.")
+	void signUp_duplicateLoginId_throwsException() {
+		// given
+		String loginId = "existingId";
+		EeosSignUpCommand command = new EeosSignUpCommand(loginId, "password", 15, "홍길동");
+
+		when(accountRepository.existsByLoginId(loginId)).thenReturn(true);
+
+		// when & then
+		assertThrows(DuplicateLoginIdException.class, () -> eeosSignUpService.signUp(command));
+
+		verify(memberRepository, never()).save(any());
+		verify(accountRepository, never()).save(any());
+		verify(tokenGenerator, never()).execute(any(), any());
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.auth.application.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -9,13 +10,11 @@ import static org.mockito.Mockito.when;
 import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
 import com.blackcompany.eeos.auth.application.exception.DuplicateLoginIdException;
-import com.blackcompany.eeos.auth.application.model.AuthorityModel;
 import com.blackcompany.eeos.auth.application.model.Role;
 import com.blackcompany.eeos.auth.application.repository.AccountRepository;
 import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
 import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
-import com.blackcompany.eeos.auth.fixture.FakeAuthority;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import java.util.Set;
@@ -51,7 +50,6 @@ class EeosSignUpServiceTest {
 		EeosSignUpCommand command = new EeosSignUpCommand(loginId, rawPassword, generation, name);
 
 		MemberModel savedMember = MemberModel.builder().id(memberId).name(name, generation).build();
-		Set<AuthorityModel> authorities = Set.of(FakeAuthority.authorityModel(1L, memberId, Role.ROLE_USER));
 		TokenModel expectedToken = TokenModel.builder()
 				.accessToken("access_token")
 				.refreshToken("refresh_token")
@@ -60,16 +58,16 @@ class EeosSignUpServiceTest {
 		when(accountRepository.existsByLoginId(loginId)).thenReturn(false);
 		when(encryptHelper.encrypt(rawPassword)).thenReturn(encryptedPassword);
 		when(memberRepository.save(any(MemberModel.class))).thenReturn(savedMember);
-		when(authorityRepository.findByMemberId(memberId)).thenReturn(authorities);
-		when(tokenGenerator.execute(any(Long.class), any(Set.class))).thenReturn(expectedToken);
+		when(tokenGenerator.execute(memberId, Set.of(Role.ROLE_USER.name()))).thenReturn(expectedToken);
 
 		// when
 		TokenModel result = eeosSignUpService.signUp(command);
 
 		// then
+		assertEquals(expectedToken, result);
 		verify(accountRepository).save(any());
 		verify(authorityRepository).save(any());
-		verify(tokenGenerator).execute(any(Long.class), any(Set.class));
+		verify(tokenGenerator).execute(memberId, Set.of(Role.ROLE_USER.name()));
 	}
 
 	@Test

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
@@ -41,7 +41,8 @@ class EeosSignUpRequestTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"short1", "onlyletters", "12345678", "!special1", "toolongpassword12345678"})
+	@ValueSource(
+			strings = {"short1", "onlyletters", "12345678", "!special1", "toolongpassword12345678"})
 	@DisplayName("조건을 만족하지 않는 비밀번호는 유효하지 않다.")
 	void invalid_password(String password) {
 		EeosSignUpRequest request = new EeosSignUpRequest("testId", password, 15, "홍길동");

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
@@ -1,0 +1,45 @@
+package com.blackcompany.eeos.auth.presentation.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EeosSignUpRequestTest {
+
+	private Validator validator;
+
+	@BeforeEach
+	void setUp() {
+		validator = Validation.buildDefaultValidatorFactory().getValidator();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"password1", "Password1", "abc12345", "ABCD1234", "abcd1234efgh5678"})
+	@DisplayName("영문+숫자 조합 8~20자 비밀번호는 유효하다.")
+	void valid_password(String password) {
+		EeosSignUpRequest request = new EeosSignUpRequest("testId", password, 15, "홍길동");
+
+		Set<ConstraintViolation<EeosSignUpRequest>> violations = validator.validate(request);
+
+		assertThat(violations).isEmpty();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"short1", "onlyletters", "12345678", "!special1", "toolongpassword12345678"})
+	@DisplayName("조건을 만족하지 않는 비밀번호는 유효하지 않다.")
+	void invalid_password(String password) {
+		EeosSignUpRequest request = new EeosSignUpRequest("testId", password, 15, "홍길동");
+
+		Set<ConstraintViolation<EeosSignUpRequest>> violations = validator.validate(request);
+
+		assertThat(violations).isNotEmpty();
+		assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("password"));
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,11 +15,18 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class EeosSignUpRequestTest {
 
+	private ValidatorFactory factory;
 	private Validator validator;
 
 	@BeforeEach
 	void setUp() {
-		validator = Validation.buildDefaultValidatorFactory().getValidator();
+		factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@AfterEach
+	void tearDown() {
+		factory.close();
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
## Summary
- `POST /api/auth/login` id/password 로그인 단위 테스트 추가 (기존 API)
- `POST /api/auth/signup` 엔드포인트 추가 (id, password, 기수, 성함)
- 비밀번호 유효성 검증: 영문+숫자 조합 8~20자
- 중복 아이디 409 Conflict 처리
- 회원가입 시 `ROLE_USER` 자동 부여 및 JWT 토큰 반환
- `/api/auth/signup` Security 인증 불필요 엔드포인트에 추가

## Test plan
- [x] `EeosLoginServiceTest` - 올바른 인증, 잘못된 비밀번호, 존재하지 않는 ID
- [x] `EeosSignUpServiceTest` - 정상 회원가입, 중복 ID 예외
- [x] `EeosSignUpRequestTest` - 비밀번호 유효/무효 케이스 (ParameterizedTest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EEOS 회원가입 기능 추가: 로그인 ID, 비밀번호, 기수, 이름으로 가입하고 토큰 발급(기본 사용자 권한 부여)
  * 로그인 ID 중복 검사 및 충돌 시 명확한 오류 반환

* **Validation**
  * 비밀번호 검증 강화: 8~20자, 영문+숫자 포함
  * 요청 필드 유효성 검사 추가(아이디, 기수, 이름 등)

* **Security**
  * 회원가입 엔드포인트를 인증 없이 접근 가능하도록 공개 처리

* **Tests**
  * 회원가입/로그인 서비스 및 요청 DTO 유효성에 대한 단위 테스트 추가

* **Documentation**
  * 공개 API에 회원가입 엔드포인트 및 요청/응답 문서화 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->