### PR TITLE
[CHORE] prometheus, grafana 도입

### DIFF
--- a/eeos/build.gradle.kts
+++ b/eeos/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
     implementation(libs.spring.boot.starter.data.redis)
     implementation(libs.spring.boot.starter.security)
 
+    // Monitoring
+    implementation(libs.micrometer.registry.prometheus)
+
     // Database
     implementation(libs.mysql.connector)
     implementation(libs.flyway.core)

--- a/eeos/docker-compose-dev.yml
+++ b/eeos/docker-compose-dev.yml
@@ -109,8 +109,10 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
     restart: always

--- a/eeos/docker-compose-dev.yml
+++ b/eeos/docker-compose-dev.yml
@@ -8,10 +8,14 @@ services:
     ports:
       - "50001:80"
     volumes:
-      - ./proxy/nginx.conf:/etc/nginx/nginx.conf
+      - ./proxy/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
+    environment:
+      - DEV_SERVER_IP=${DEV_SERVER_IP}
     restart: always
     networks:
       - external-network
+    command: >
+      /bin/sh -c "envsubst '$$DEV_SERVER_IP' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
   eeos-mysql:
     container_name: eeos-mysql
     image: mysql/mysql-server:8.0.32
@@ -76,6 +80,48 @@ services:
     networks:
       - internal-network
       - external-network
+
+  # Monitoring Stack
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml.template:ro
+      - prometheus-data:/prometheus
+    environment:
+      - PROD_SERVER_IP=${PROD_SERVER_IP}
+    entrypoint: /bin/sh
+    command: >
+      -c "apk add --no-cache gettext && envsubst '$$PROD_SERVER_IP' < /etc/prometheus/prometheus.yml.template > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle"
+    restart: always
+    networks:
+      - internal-network
+      - external-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: always
+    networks:
+      - internal-network
+      - external-network
+
 networks:
   internal-network:
   external-network:
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/eeos/gradle/libs.versions.toml
+++ b/eeos/gradle/libs.versions.toml
@@ -69,6 +69,9 @@ firebase-admin = { group = "com.google.firebase", name = "firebase-admin", versi
 spring-retry = { group = "org.springframework.retry", name = "spring-retry", version.ref = "spring-retry" }
 spring-aspects = { group = "org.springframework", name = "spring-aspects" }
 
+# Monitoring
+micrometer-registry-prometheus = { group = "io.micrometer", name = "micrometer-registry-prometheus" }
+
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/eeos/monitoring/grafana/provisioning/alerting/alerting.yml
+++ b/eeos/monitoring/grafana/provisioning/alerting/alerting.yml
@@ -1,0 +1,70 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: Slack
+    receivers:
+      - uid: slack-receiver
+        type: slack
+        settings:
+          url: ${SLACK_WEBHOOK_URL}
+          title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+          text: |
+            {{ range .Alerts }}
+            *Alert:* {{ .Annotations.summary }}
+            *Description:* {{ .Annotations.description }}
+            *Severity:* {{ .Labels.severity }}
+            {{ end }}
+
+policies:
+  - orgId: 1
+    receiver: Slack
+    group_by: ['alertname', 'job']
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 1h
+
+groups:
+  - orgId: 1
+    name: service-down
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: eeos-service-down
+        title: 'EEOS Service Down'
+        condition: C
+        for: 2m
+        noDataState: Alerting
+        execErrState: Alerting
+        annotations:
+          summary: 'EEOS 서비스 다운'
+          description: '{{ $labels.job }} 서비스가 응답하지 않습니다. (instance: {{ $labels.instance }})'
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: 'up{job=~"eeos.*"}'
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              conditions:
+                - evaluator:
+                    params: [1]
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last

--- a/eeos/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/eeos/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: https://prometheus:9090
+    isDefault: true
+    editable: false

--- a/eeos/monitoring/prometheus.yml
+++ b/eeos/monitoring/prometheus.yml
@@ -1,0 +1,36 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: []
+
+rule_files: []
+
+scrape_configs:
+  # Prometheus 자체 모니터링
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  # EEOS 운영 서버 모니터링 : 상태 모니터링 (Nginx 경유)
+  - job_name: 'eeos-prod'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['${PROD_SERVER_IP}:50001']
+        labels:
+          environment: 'production'
+          application: 'eeos'
+
+  # EEOS 개발 서버 모니터링 : 부하테스트
+  - job_name: 'eeos-dev'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['eeos-backend:8080']
+        labels:
+          environment: 'development'
+          application: 'eeos'

--- a/eeos/proxy/nginx.conf
+++ b/eeos/proxy/nginx.conf
@@ -24,6 +24,18 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
+
+        # Actuator endpoints for monitoring (Prometheus)
+        location /actuator/ {
+            proxy_pass http://docker-eeos-backend/actuator/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            # IP whitelist - 개발서버만 허용
+            allow ${DEV_SERVER_IP};
+            deny all;
+        }
     }
 
     access_log  /var/log/nginx/access.log;

--- a/eeos/src/main/resources/application-actuator.yml
+++ b/eeos/src/main/resources/application-actuator.yml
@@ -7,7 +7,17 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
-      base-path: "/manage"
-  server:
-    port: 8081
+        include: health, prometheus, info, metrics
+      base-path: "/actuator"
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    tags:
+      application: eeos


### PR DESCRIPTION
## 📌 관련 이슈
closes #310 
## ✒️ 작업 내용
- prometheus, grafana 를 인프라에 추가하였습니다.
- 모니터링을 개발용서버에 적용하여, 개발용 및 운영용 서버를 모니터링할 수 있도록 구현했습니다.
- 개발용 및 운영용 서버 다운시 슬랙 #모니터링 채널로 알림을 보냅니다.
- 로컬에서 테스트하는것에 한계가 있어 배포후 테스트 할 예정입니다.
### 스크린샷 🏞️ (선택)

## 💬 REVIEWER 중요 전달사항
.env 파일에 환경변수가 추가되었습니다. (.env.properties 아닙니다!)
상세 추가 내용은 노션 .env 페이지에서 확인가능합니다!

## 고민공유 및 변경사항
- 기존에 8081로 되어있던 actuator 설정을 8080으로 통일하고, nginx 에서 ip 화이트 리스트로 관리하여 외부에서는 actuator 로 접근할 수 없도록 했습니다.
- 이 방법을 채택한 이유는 actuator 를 위해 추가 포트(8081)를 허용하는것보다 화이트 리스트로 접근을 제어하는것이 더 안전하다고 판단했기 때문입니다.

다른 의견이 있다면 공유 부탁드립니다. 반영하도록 하겠습니다!🙌
