### PR TITLE
feat: Web/App 인증 분리 + PKCE 도입

### DIFF
--- a/docs/superpowers/plans/2026-03-22-web-app-auth-separation.md
+++ b/docs/superpowers/plans/2026-03-22-web-app-auth-separation.md
@@ -1,0 +1,38 @@
+# Web/App 인증 분리 + PKCE 구현 계획
+
+**Goal:** Web/App 클라이언트를 분리하여 Web은 쿠키 기반, App은 Authorization Code + PKCE 기반 인증을 지원한다.
+
+**Spec:** `docs/superpowers/specs/2026-03-22-web-app-auth-separation-design.md`
+
+## 진행 상황
+
+### Chunk 1: Client 등록 (완료)
+- [x] Task 1: ClientType enum
+- [x] Task 2: ClientEntity + Repository
+- [x] Task 3: Client exceptions
+- [x] Task 4: ClientService
+- [x] Task 5: ClientController + Swagger
+
+### Chunk 2: Token/PKCE (완료)
+- [x] Task 6: TokenProvider clientType/clientId claims
+- [x] Task 7: PkceValidator
+- [x] Task 8: AuthorizationCodeRepository
+
+### Chunk 3: Rate Limiting + Cookie (완료)
+- [x] Task 9: LoginRateLimiter
+- [x] Task 10: AuthCookieManager update
+
+### Chunk 4: 새 엔드포인트 (완료)
+- [x] Task 11: AuthenticationTokenGenerator extend
+- [x] Task 12: OAuth2LoginService
+- [x] Task 13: TokenExchangeService
+- [x] Task 14: OAuth2Controller + Swagger
+
+### Chunk 5: 분기/정리 (진행중)
+- [x] Task 15: ReissueService Web/App branching
+- [x] Task 16: Logout Web/App branching
+- [x] Task 17: @Deprecated 처리 (Slack OAuth 엔드포인트)
+- [ ] Task 18: InterceptorConfig update
+- [ ] Task 19: Application config
+- [ ] Task 20: Flyway migration for oauth_client tables
+- [ ] Task 21: Final verification

--- a/docs/superpowers/specs/2026-03-22-web-app-auth-separation-design.md
+++ b/docs/superpowers/specs/2026-03-22-web-app-auth-separation-design.md
@@ -1,0 +1,359 @@
+# Web/App 인증 분리 + PKCE 설계
+
+## 배경
+
+- `auth.econovation.kr`은 여러 서비스가 공유하는 인증 서버 (현재는 EEOS와 미분리 상태)
+- 웹은 쿠키로 AT/RT 전달 가능하지만, 앱은 도메인이 달라 쿠키 수신 불가
+- 앱을 위해 OAuth2.0 Authorization Code + PKCE 방식 도입
+- Slack OAuth 완전 제거, 자체 로그인(email/password)만 지원
+- 앱은 시스템 브라우저(Chrome Custom Tab, ASWebAuthenticationSession)를 통해 /authorize에 접근 (RFC 8252 — WebView 사용 금지)
+
+## 결정 사항
+
+| 항목 | 결정 |
+|------|------|
+| Client 등록 | 동적 등록 API 제공 (관리자 권한) |
+| Web/App 구분 | client_id + redirect_uri로 판별 |
+| Client 인증 | Web: client_secret (confidential), App: PKCE만 (public, secret 미발급) |
+| Authorization code 저장 | Redis (TTL 60초, 일회용, 128bit 이상 SecureRandom) |
+| PKCE | App 필수, S256만 지원 |
+| RT rotation | 기존 유지 (Redis 블랙리스트) |
+| CSRF 방지 | state 파라미터 필수 |
+| reissue/logout 분기 | RT 내부 clientType 클레임 기준 |
+| /token Content-Type | application/x-www-form-urlencoded (RFC 6749 표준) |
+
+---
+
+## 1. Client 등록 모델 + API
+
+### Entity
+
+```
+ClientEntity {
+  id: Long (PK)
+  clientId: String (UUID, 자동생성, unique)
+  clientSecret: String (BCrypt hashed, WEB만 존재. APP은 null)
+  clientName: String
+  clientType: enum WEB | APP
+  redirectUris: Set<String>  // 허용된 redirect URI 목록 (최대 10개, URI당 최대 512자)
+  createdAt: LocalDateTime
+}
+```
+
+### API
+
+```
+POST /api/auth/clients
+권한: 관리자(isAdmin)
+Request: { clientName, clientType, redirectUris }
+Response:
+  - WEB: { clientId, clientSecret }  <- 최초 1회만 평문 노출
+  - APP: { clientId }                <- secret 미발급
+```
+
+- WEB (Confidential Client): clientSecret 발급, BCrypt 해시 저장
+- APP (Public Client): clientSecret 미발급, PKCE가 유일한 보안 메커니즘 (RFC 8252, RFC 9700 준수)
+- clientId는 UUID 자동생성
+
+---
+
+## 2. 인증 흐름
+
+### 공통 진입점
+
+```
+GET /api/auth/authorize
+  ?client_id={clientId}
+  &redirect_uri={redirectUri}
+  &response_type=code
+  &state={randomString}           <- 필수 (CSRF 방지)
+  &code_challenge={hash}          <- APP만 필수
+  &code_challenge_method=S256     <- APP만 필수
+```
+
+서버: client_id로 클라이언트 조회 -> redirect_uri 검증 -> response_type 검증 -> 로그인 페이지로 redirect (파라미터를 query string으로 전달)
+
+참고: Web 클라이언트는 response_type=code로 요청하지만, 실제로는 code를 발급하지 않고 쿠키를 직접 발급한다.
+response_type 파라미터는 OAuth2 표준 형식 준수 목적으로 유지하며, Web의 분기는 clientType 기준이다.
+
+### 사용자 인증 단계
+
+`/authorize`는 직접 인증을 수행하지 않는다. 파라미터 검증 후 로그인 페이지로 리다이렉트한다.
+Slack OAuth가 없으므로 외부 콜백이 없고, Redis 인증 세션이 필요 없다.
+
+로그인 페이지의 form:
+
+```html
+<form action="/api/auth/login" method="POST">
+  <input type="hidden" name="client_id" value="{clientId}" />
+  <input type="hidden" name="redirect_uri" value="{redirectUri}" />
+  <input type="hidden" name="state" value="{state}" />
+  <input type="hidden" name="code_challenge" value="{codeChallenge}" />
+  <input type="hidden" name="code_challenge_method" value="S256" />
+
+  <input type="text" name="email" />
+  <input type="password" name="password" />
+  <button type="submit">로그인</button>
+</form>
+```
+
+서버 `/api/auth/login` 처리 (순서 고정 — redirect 전에 반드시 검증 완료):
+
+```
+1. client_id로 DB에서 클라이언트 조회 (실패 → 400, redirect 안 함)
+2. redirect_uri가 해당 클라이언트의 허용 목록에 있는지 재검증 (실패 → 400, redirect 안 함)
+   (hidden field는 조작 가능하므로 /authorize에서 검증했더라도 반드시 재검증)
+3. credentials 검증
+   - 실패 → 로그인 페이지로 303 Redirect (쿼리 파라미터로 hidden fields + 에러 메시지 전달)
+     303 → /login-page?client_id={}&redirect_uri={}&state={}&code_challenge={}&error=invalid_credentials
+     (Redis 의존 없이 상태 유지. code_challenge는 공개값이므로 URL 노출 무관)
+   - 사용자가 "취소" 버튼 클릭 → redirect_uri?error=access_denied&state={state}
+   ※ redirect_uri 검증 완료 상태이므로 redirect 안전
+4. clientType에 따라 분기
+```
+
+### Web 경로
+
+```
+1. 사용자 인증 성공 (clientType=WEB)
+2. AT/RT를 쿠키에 설정 (기존과 동일)
+   RT에 clientType=WEB, clientId 클레임 포함
+3. redirect_uri?state={state} 로 303 See Other Redirect
+```
+
+### App 경로
+
+```
+1. 사용자 인증 성공 (clientType=APP)
+2. authorization_code 생성 (128bit 이상 SecureRandom) -> Redis 저장 (TTL 60초)
+   key: "auth_code:{code}"
+   value: { memberId, clientId, codeChallenge, codeChallengeMethod, redirectUri }
+3. redirect_uri?code={authorization_code}&state={state} 로 303 See Other Redirect
+4. 앱이 토큰 교환 요청:
+
+POST /api/auth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code={code}&code_verifier={verifier}&redirect_uri={uri}&client_id={clientId}
+
+5. 서버: client_id로 클라이언트 조회 (APP 타입 확인)
+   -> code로 Redis 조회 -> DEL(일회성)
+   -> code의 clientId와 요청 client_id 일치 검증
+   -> redirect_uri 일치 검증 -> PKCE 검증
+   -> AT/RT 발급 (RT에 clientType=APP, clientId 클레임 포함)
+   -> JSON body 반환
+```
+
+### 토큰 교환 응답 (App)
+
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+---
+
+## 3. PKCE
+
+```
+1. 앱이 code_verifier 생성 (43~128자 랜덤 문자열)
+2. code_challenge = BASE64URL(SHA256(code_verifier))
+3. /authorize 요청 시 code_challenge + method=S256 전달
+4. 로그인 폼의 hidden field로 전달 -> Redis auth_code에 저장
+5. /token 요청 시 code_verifier 전달
+6. 서버: BASE64URL(SHA256(code_verifier)) == 저장된 code_challenge 검증
+```
+
+- Web: PKCE 불필요 (쿠키 직접 발급, code 교환 없음)
+- App: PKCE 필수. code_challenge 없으면 /authorize 거부
+- code_challenge_method: S256만 지원 (plain 미지원)
+
+---
+
+## 4. RT 기반 분기 (reissue / logout / withdraw)
+
+### 원칙
+
+RT 발급 시 `clientType`, `clientId` 클레임을 포함한다.
+분기는 RT 내부 정보 기준이며, 외부 신호(body의 client_id 유무 등)에 의존하지 않는다.
+
+### reissue
+
+```
+POST /api/auth/reissue
+
+1. RT 추출 (충돌 방지)
+   - 쿠키에 RT 있고 body에도 RT 있음 -> 400 (ambiguous_request) 거부
+   - 쿠키에만 RT 있음 -> 쿠키에서 추출 (WEB 경로)
+   - body에만 RT 있음 -> body에서 추출 (APP 경로, client_id 필수)
+   - 둘 다 없음 -> 401
+
+2. RT 내부의 clientType 확인
+
+3. clientType == WEB:
+   - RT가 쿠키에서 온 게 아니면 거부
+   - 새 AT/RT -> 쿠키로 응답
+
+4. clientType == APP:
+   - body의 client_id와 RT 내부 clientId 일치 확인
+   - 새 AT/RT -> JSON body로 응답
+```
+
+### logout
+
+```
+POST /api/auth/logout
+
+1. RT 추출 (reissue와 동일 로직)
+2. RT 내부 clientType 확인
+3. WEB: RT 블랙리스트 등록 + 쿠키 삭제
+4. APP: RT 블랙리스트 등록 (쿠키 삭제 생략)
+```
+
+### withdraw
+
+기존 로직 유지 + RT 추출 방식만 위와 동일하게 분기
+
+---
+
+## 5. Failure Design
+
+### 에러 흐름
+
+```
+[/api/auth/authorize]
+  -> client_id 미존재 -> 400 (invalid_client)
+  -> redirect_uri 미등록 -> 400 (invalid_redirect_uri) <- redirect 하면 안 됨
+  -> response_type != "code" -> 400 (unsupported_response_type)
+  -> state 누락 -> 400 (invalid_request)
+  -> APP인데 code_challenge 누락 -> 400 (code_challenge_required)
+
+[/api/auth/login] (처리 순서 = 에러 우선순위)
+  -> 1. client_id 미존재 -> 400 (invalid_client, redirect 안 함)
+  -> 2. redirect_uri 재검증 실패 -> 400 (invalid_redirect_uri, redirect 안 함)
+  -> 3a. credentials 인증 실패 -> 로그인 페이지로 303 Redirect (쿼리 파라미터로 에러+hidden fields 전달)
+  -> 3b. 사용자 취소 -> redirect_uri?error=access_denied&state={state}
+     ※ redirect_uri 검증 완료 후이므로 안전
+
+[/api/auth/token]
+  -> client_id 누락 또는 미존재 -> 400 (invalid_client)
+  -> code의 clientId와 요청 client_id 불일치 -> 400 (invalid_client)
+  -> code 만료 (Redis TTL) -> 400 (invalid_grant)
+  -> code 이미 사용됨 (Redis에 없음) -> 400 (invalid_grant)
+  -> redirect_uri 불일치 -> 400 (invalid_grant)
+  -> PKCE 검증 실패 -> 400 (invalid_grant)
+  -> grant_type 미지원 -> 400 (unsupported_grant_type)
+
+[/api/auth/reissue]
+  -> 쿠키와 body 모두 RT 존재 -> 400 (ambiguous_request)
+  -> RT 없음 (쿠키, body 모두) -> 401
+  -> RT 만료/블랙리스트 -> 401
+  -> WEB인데 쿠키가 아닌 경로로 RT 전달 -> 401
+  -> APP인데 client_id 불일치 -> 401
+
+[/api/auth/clients]
+  -> 비관리자 요청 -> 403
+  -> redirectUris 빈 값 -> 400
+  -> redirectUris 10개 초과 -> 400
+  -> redirectUri 512자 초과 -> 400
+  -> clientType 잘못된 값 -> 400
+```
+
+### 보안 규칙
+
+| 규칙 | 이유 |
+|------|------|
+| redirect_uri 불일치 시 redirect 하지 않고 에러 응답 | open redirect 공격 방지 |
+| /login에서 client_id + redirect_uri 재검증 | hidden field 조작 대응 |
+| code 재사용: Redis DEL로 소멸 | 60초 TTL + 일회성으로 차단 |
+| PKCE 실패 시 구체적 이유 미노출 | code_verifier 추측 공격 방지 |
+| RT 내부 clientType으로 분기 | 외부 신호 조작 방지 |
+| reissue 시 쿠키+body 동시 RT 거부 | 경로 혼란 공격 방지 |
+
+### Rate Limiting
+
+`/api/auth/login`은 brute force 공격 대상이므로 시도 횟수를 제한한다.
+
+```
+정책:
+- IP당: 분당 20회 초과 시 429 (Too Many Requests)
+- 계정당: 5회 연속 실패 시 5분간 해당 계정 잠금 (lockout)
+- lockout 해제: 5분 경과 후 자동 해제
+- 구현: Redis 카운터 (key: "login_fail:{email}" 또는 "login_fail:{ip}", TTL: 60초/300초)
+- lockout 에러 응답: 일반 credentials 실패와 동일한 메시지 사용 (계정 존재 여부 노출 방지)
+```
+
+### 쿠키 속성 (Web 경로)
+
+Web 경로에서 AT/RT를 쿠키로 전달할 때의 속성을 명시한다.
+state 파라미터는 OAuth 인증 흐름의 CSRF만 방지하며, 인증 이후 API 호출의 CSRF는 쿠키 속성으로 방어한다.
+
+```
+AT 쿠키:
+  Name: eeos_access_token
+  HttpOnly: true       (JavaScript 접근 차단)
+  Secure: true         (HTTPS만)
+  SameSite: Lax        (cross-site POST 차단, 같은 사이트 GET 허용)
+  Path: /api
+  Domain: ${COOKIE_TOKEN_DOMAIN}
+  Max-Age: AT 유효시간
+
+RT 쿠키:
+  Name: eeos_refresh_token
+  HttpOnly: true
+  Secure: true
+  SameSite: Lax
+  Path: /api/auth           (reissue, logout, withdraw 모두에서 전송 필요)
+  Domain: ${COOKIE_TOKEN_DOMAIN}
+  Max-Age: RT 유효시간
+```
+
+참고: 기존 시스템은 SameSite=None이었으나, 보안 강화를 위해 Lax로 변경한다.
+SameSite=Lax는 cross-site POST 요청에서 쿠키가 자동 전송되지 않아 CSRF를 방어한다.
+
+### 선택적 보강 (현재 미적용)
+
+- **code_challenge hidden field 조작 방어**: 공격자가 code_challenge를 자기 값으로 바꿔치기하면 자기 code_verifier로 토큰 교환 가능. 단, redirect_uri가 등록값으로 고정되어 있어 code 가로채기가 어려우므로 실질적 위험은 낮음. 필요 시 /authorize에서 code_challenge를 서명된 쿠키나 HMAC 토큰으로 보호하여 /login에서 대조 가능.
+
+### Redis 장애 시
+
+```
+Redis 장애 시:
+├─ Web 신규 로그인: 가능 (Redis 미사용)
+├─ App 신규 로그인: 불가 (authorization_code 저장 불가)
+├─ RT 갱신 (Web/App 공통): RT 블랙리스트 확인 불가
+│   -> 안전 우선 정책: 갱신 거부
+│   -> 가용성 우선 정책: 갱신 허용 (탈취된 RT 차단 불가 감수)
+├─ Rate Limiting: 카운터 확인 불가
+│   → 가용성 우선 정책: Rate Limit 없이 허용 (brute force 노출 감수)
+│   ※ Redis 장애가 brute force 공격 창구가 될 수 있음을 인식
+├─ 기존 AT로 API 호출: 영향 없음 (AT 만료 전까지)
+└─ logout/withdraw: RT 블랙리스트 등록 불가
+```
+
+---
+
+## 6. 엔드포인트 정리
+
+### 새 엔드포인트
+
+| Method | Path                   | 용도                                                    |
+|--------|------------------------|---------------------------------------------------------|
+| POST   | `/api/auth/clients`    | Client 등록 (관리자)                                    |
+| GET    | `/api/auth/authorize`  | 파라미터 검증 -> 로그인 페이지 redirect                 |
+| POST   | `/api/auth/login`      | 자체 로그인 인증 + Web/App 분기                         |
+| POST   | `/api/auth/token`      | code -> AT/RT 교환 (App, x-www-form-urlencoded)         |
+| POST   | `/api/auth/reissue`    | RT 갱신 (RT 내부 clientType으로 분기)                   |
+| POST   | `/api/auth/logout`     | 로그아웃 (RT 내부 clientType으로 분기)                  |
+| POST   | `/api/auth/withdraw`   | 회원탈퇴                                                |
+
+### Deprecated 대상
+
+| Method | Path                                 | 상태                                        |
+|--------|--------------------------------------|---------------------------------------------|
+| POST   | `/api/auth/login/{oauthServerType}`  | @Deprecated (Slack OAuth, 추후 제거 예정)   |
+| POST   | `/api/auth/login` (기존 버전)        | @Deprecated (새 `/api/auth/login/oauth2`로 대체) |

--- a/docs/superpowers/specs/2026-03-22-web-app-auth-separation-design.md
+++ b/docs/superpowers/specs/2026-03-22-web-app-auth-separation-design.md
@@ -356,4 +356,4 @@ Redis 장애 시:
 | Method | Path                                 | 상태                                        |
 |--------|--------------------------------------|---------------------------------------------|
 | POST   | `/api/auth/login/{oauthServerType}`  | @Deprecated (Slack OAuth, 추후 제거 예정)   |
-| POST   | `/api/auth/login` (기존 버전)        | @Deprecated (새 `/api/auth/login/oauth2`로 대체) |
+| POST   | `/api/auth/login` (기존 버전)        | @Deprecated (새 `/api/auth/login`로 대체) |

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/AuthorizationCodeData.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/AuthorizationCodeData.java
@@ -1,0 +1,19 @@
+package com.blackcompany.eeos.auth.application.domain;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthorizationCodeData implements Serializable {
+	private Long memberId;
+	private String clientId;
+	private String codeChallenge;
+	private String codeChallengeMethod;
+	private String redirectUri;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/ClientType.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/ClientType.java
@@ -1,0 +1,16 @@
+package com.blackcompany.eeos.auth.application.domain;
+
+public enum ClientType {
+	WEB(true),
+	APP(false);
+
+	private final boolean confidential;
+
+	ClientType(boolean confidential) {
+		this.confidential = confidential;
+	}
+
+	public boolean isConfidential() {
+		return confidential;
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/PkceValidator.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/PkceValidator.java
@@ -1,0 +1,29 @@
+package com.blackcompany.eeos.auth.application.domain;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class PkceValidator {
+
+	private PkceValidator() {}
+
+	public static boolean validate(String codeVerifier, String codeChallenge, String method) {
+		if (!"S256".equals(method)) {
+			throw new IllegalArgumentException("Unsupported code_challenge_method: " + method);
+		}
+
+		try {
+			byte[] digest =
+					MessageDigest.getInstance("SHA-256")
+							.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+			String computed = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+			return MessageDigest.isEqual(
+					computed.getBytes(StandardCharsets.UTF_8),
+					codeChallenge.getBytes(StandardCharsets.UTF_8));
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("SHA-256 not available", e);
+		}
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/token/TokenProvider.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/token/TokenProvider.java
@@ -17,6 +17,8 @@ public class TokenProvider {
 
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 	private static final String ROLE_CLAIM_KEY = "role";
+	private static final String CLIENT_TYPE_CLAIM_KEY = "clientType";
+	private static final String CLIENT_ID_CLAIM_KEY = "clientId";
 	private final SecretKey accessSecretKey;
 	private final SecretKey refreshSecretKey;
 	private final long accessValidTime;
@@ -77,6 +79,21 @@ public class TokenProvider {
 		return Jwts.builder()
 				.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
 				.claim(MEMBER_ID_CLAIM_KEY, memberId)
+				.setIssuedAt(now)
+				.setExpiration(new Date(now.getTime() + refreshValidTime))
+				.signWith(refreshSecretKey)
+				.compact();
+	}
+
+	public String createRefreshToken(
+			final Long memberId, final String clientType, final String clientId) {
+		final Date now = new Date();
+
+		return Jwts.builder()
+				.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+				.claim(MEMBER_ID_CLAIM_KEY, memberId)
+				.claim(CLIENT_TYPE_CLAIM_KEY, clientType)
+				.claim(CLIENT_ID_CLAIM_KEY, clientId)
 				.setIssuedAt(now)
 				.setExpiration(new Date(now.getTime() + refreshValidTime))
 				.signWith(refreshSecretKey)

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/token/TokenResolver.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/domain/token/TokenResolver.java
@@ -23,6 +23,8 @@ public class TokenResolver {
 
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 	private static final String ROLE_CLAIM_KEY = "role";
+	private static final String CLIENT_TYPE_CLAIM_KEY = "clientType";
+	private static final String CLIENT_ID_CLAIM_KEY = "clientId";
 	private final SecretKey accessSecretKey;
 	private final SecretKey refreshSecretKey;
 
@@ -63,6 +65,14 @@ public class TokenResolver {
 
 	public Long getUserDataByRefreshToken(final String token) {
 		return getClaimValue(getRefreshClaims(token), MEMBER_ID_CLAIM_KEY);
+	}
+
+	public String getClientTypeByRefreshToken(final String token) {
+		return getRefreshClaims(token).get(CLIENT_TYPE_CLAIM_KEY, String.class);
+	}
+
+	public String getClientIdByRefreshToken(final String token) {
+		return getRefreshClaims(token).get(CLIENT_ID_CLAIM_KEY, String.class);
 	}
 
 	private SecretKey generateSecretKey(String key) {

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/request/ClientRegistrationRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/request/ClientRegistrationRequest.java
@@ -1,0 +1,15 @@
+package com.blackcompany.eeos.auth.application.dto.request;
+
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClientRegistrationRequest {
+	private String clientName;
+	private String clientType;
+	private Set<String> redirectUris;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/response/ClientRegistrationResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/response/ClientRegistrationResponse.java
@@ -1,0 +1,13 @@
+package com.blackcompany.eeos.auth.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ClientRegistrationResponse {
+	private String clientId;
+	private String clientSecret;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/AmbiguousTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/AmbiguousTokenException.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class AmbiguousTokenException extends BusinessException {
+	private static final String FAIL_CODE = "4013";
+
+	public AmbiguousTokenException() {
+		super(FAIL_CODE, HttpStatus.BAD_REQUEST);
+	}
+
+	@Override
+	public String getMessage() {
+		return "토큰 전달 경로가 모호합니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/AmbiguousTokenException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/AmbiguousTokenException.java
@@ -4,7 +4,7 @@ import com.blackcompany.eeos.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
 public class AmbiguousTokenException extends BusinessException {
-	private static final String FAIL_CODE = "4013";
+	private static final String FAIL_CODE = "4017";
 
 	public AmbiguousTokenException() {
 		super(FAIL_CODE, HttpStatus.BAD_REQUEST);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidClientException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidClientException.java
@@ -4,7 +4,7 @@ import com.blackcompany.eeos.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
 public class InvalidClientException extends BusinessException {
-	private static final String FAIL_CODE = "4010";
+	private static final String FAIL_CODE = "4014";
 
 	public InvalidClientException() {
 		super(FAIL_CODE, HttpStatus.BAD_REQUEST);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidClientException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidClientException.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidClientException extends BusinessException {
+	private static final String FAIL_CODE = "4010";
+
+	public InvalidClientException() {
+		super(FAIL_CODE, HttpStatus.BAD_REQUEST);
+	}
+
+	@Override
+	public String getMessage() {
+		return "유효하지 않은 클라이언트입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidGrantException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidGrantException.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidGrantException extends BusinessException {
+	private static final String FAIL_CODE = "4012";
+
+	public InvalidGrantException() {
+		super(FAIL_CODE, HttpStatus.BAD_REQUEST);
+	}
+
+	@Override
+	public String getMessage() {
+		return "유효하지 않은 인가 코드입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidGrantException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidGrantException.java
@@ -4,7 +4,7 @@ import com.blackcompany.eeos.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
 public class InvalidGrantException extends BusinessException {
-	private static final String FAIL_CODE = "4012";
+	private static final String FAIL_CODE = "4016";
 
 	public InvalidGrantException() {
 		super(FAIL_CODE, HttpStatus.BAD_REQUEST);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidRedirectUriException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidRedirectUriException.java
@@ -4,7 +4,7 @@ import com.blackcompany.eeos.common.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
 public class InvalidRedirectUriException extends BusinessException {
-	private static final String FAIL_CODE = "4011";
+	private static final String FAIL_CODE = "4015";
 
 	public InvalidRedirectUriException() {
 		super(FAIL_CODE, HttpStatus.BAD_REQUEST);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidRedirectUriException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidRedirectUriException.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRedirectUriException extends BusinessException {
+	private static final String FAIL_CODE = "4011";
+
+	public InvalidRedirectUriException() {
+		super(FAIL_CODE, HttpStatus.BAD_REQUEST);
+	}
+
+	@Override
+	public String getMessage() {
+		return "등록되지 않은 redirect URI입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/RateLimitExceededException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/RateLimitExceededException.java
@@ -1,0 +1,17 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class RateLimitExceededException extends BusinessException {
+	private static final String FAIL_CODE = "4290";
+
+	public RateLimitExceededException() {
+		super(FAIL_CODE, HttpStatus.TOO_MANY_REQUESTS);
+	}
+
+	@Override
+	public String getMessage() {
+		return "로그인 시도 횟수를 초과했습니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/ClientService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/ClientService.java
@@ -1,0 +1,90 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.exception.InvalidClientException;
+import com.blackcompany.eeos.auth.application.exception.InvalidRedirectUriException;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.auth.persistence.client.ClientRepository;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClientService {
+
+	private static final int MAX_REDIRECT_URIS = 10;
+	private static final int MAX_REDIRECT_URI_LENGTH = 512;
+	private static final int SECRET_BYTE_LENGTH = 32;
+
+	private final ClientRepository clientRepository;
+
+	@Transactional
+	public ClientRegistrationResult register(
+			String clientName, ClientType clientType, Set<String> redirectUris) {
+		validateRedirectUris(redirectUris);
+
+		String clientId = UUID.randomUUID().toString();
+		String rawSecret = null;
+		String hashedSecret = null;
+
+		if (clientType.isConfidential()) {
+			rawSecret = generateSecret();
+			hashedSecret = BCrypt.hashpw(rawSecret, BCrypt.gensalt());
+		}
+
+		ClientEntity entity =
+				ClientEntity.builder()
+						.clientId(clientId)
+						.clientSecret(hashedSecret)
+						.clientName(clientName)
+						.clientType(clientType)
+						.build();
+
+		redirectUris.forEach(entity::addRedirectUri);
+		clientRepository.save(entity);
+
+		return new ClientRegistrationResult(clientId, rawSecret);
+	}
+
+	public ClientEntity findAndValidateRedirectUri(String clientId, String redirectUri) {
+		ClientEntity client =
+				clientRepository
+						.findByClientIdWithRedirectUris(clientId)
+						.orElseThrow(InvalidClientException::new);
+
+		if (!client.hasRedirectUri(redirectUri)) {
+			throw new InvalidRedirectUriException();
+		}
+
+		return client;
+	}
+
+	private void validateRedirectUris(Set<String> redirectUris) {
+		if (redirectUris == null || redirectUris.isEmpty()) {
+			throw new InvalidRedirectUriException();
+		}
+		if (redirectUris.size() > MAX_REDIRECT_URIS) {
+			throw new InvalidRedirectUriException();
+		}
+		for (String uri : redirectUris) {
+			if (uri.length() > MAX_REDIRECT_URI_LENGTH) {
+				throw new InvalidRedirectUriException();
+			}
+		}
+	}
+
+	private String generateSecret() {
+		byte[] bytes = new byte[SECRET_BYTE_LENGTH];
+		new SecureRandom().nextBytes(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+
+	public record ClientRegistrationResult(String clientId, String clientSecret) {}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/OAuth2LoginService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/OAuth2LoginService.java
@@ -1,0 +1,69 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import com.blackcompany.eeos.auth.application.domain.AuthorizationCodeData;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
+import com.blackcompany.eeos.auth.application.support.LoginRateLimiter;
+import com.blackcompany.eeos.auth.persistence.AuthorizationCodeRepository;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2LoginService {
+
+	private final AuthService authService;
+	private final ClientService clientService;
+	private final AuthenticationTokenGenerator tokenGenerator;
+	private final AuthorizationCodeRepository codeRepository;
+	private final LoginRateLimiter rateLimiter;
+
+	public TokenModel loginForWeb(
+			String clientId, String redirectUri, String email, String password, String ip) {
+		rateLimiter.checkRateLimit(ip, email);
+		ClientEntity client = clientService.findAndValidateRedirectUri(clientId, redirectUri);
+
+		MemberModel member = authenticateWithRateLimit(email, password, ip);
+		rateLimiter.resetAccountCounter(email);
+
+		return tokenGenerator.execute(
+				member.getMemberId(), client.getClientType().name(), client.getClientId());
+	}
+
+	public String loginForApp(
+			String clientId,
+			String redirectUri,
+			String email,
+			String password,
+			String ip,
+			String codeChallenge,
+			String codeChallengeMethod) {
+		rateLimiter.checkRateLimit(ip, email);
+		ClientEntity client = clientService.findAndValidateRedirectUri(clientId, redirectUri);
+
+		MemberModel member = authenticateWithRateLimit(email, password, ip);
+		rateLimiter.resetAccountCounter(email);
+
+		AuthorizationCodeData codeData =
+				AuthorizationCodeData.builder()
+						.memberId(member.getMemberId())
+						.clientId(client.getClientId())
+						.codeChallenge(codeChallenge)
+						.codeChallengeMethod(codeChallengeMethod)
+						.redirectUri(redirectUri)
+						.build();
+
+		return codeRepository.save(codeData);
+	}
+
+	private MemberModel authenticateWithRateLimit(String email, String password, String ip) {
+		try {
+			return authService.authenticate(email, password);
+		} catch (Exception e) {
+			rateLimiter.recordFailure(ip, email);
+			throw e;
+		}
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/ReissueService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/ReissueService.java
@@ -26,6 +26,12 @@ public class ReissueService implements ReissueUsecase {
 		Long memberId = tokenResolver.getUserDataByRefreshToken(token);
 		saveUsedToken(token, memberId);
 
+		String clientType = tokenResolver.getClientTypeByRefreshToken(token);
+		if (clientType != null) {
+			String clientId = tokenResolver.getClientIdByRefreshToken(token);
+			return authenticationTokenGenerator.execute(memberId, clientType, clientId);
+		}
+
 		return authenticationTokenGenerator.execute(memberId);
 	}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/TokenExchangeService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/TokenExchangeService.java
@@ -1,0 +1,49 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import com.blackcompany.eeos.auth.application.domain.AuthorizationCodeData;
+import com.blackcompany.eeos.auth.application.domain.PkceValidator;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.exception.InvalidClientException;
+import com.blackcompany.eeos.auth.application.exception.InvalidGrantException;
+import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
+import com.blackcompany.eeos.auth.persistence.AuthorizationCodeRepository;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.auth.persistence.client.ClientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenExchangeService {
+
+	private final AuthorizationCodeRepository codeRepository;
+	private final ClientRepository clientRepository;
+	private final AuthenticationTokenGenerator tokenGenerator;
+
+	public TokenModel exchange(
+			String code, String codeVerifier, String redirectUri, String clientId) {
+		AuthorizationCodeData codeData =
+				codeRepository.findAndDelete(code).orElseThrow(InvalidGrantException::new);
+
+		if (!codeData.getClientId().equals(clientId)) {
+			throw new InvalidClientException();
+		}
+
+		if (!codeData.getRedirectUri().equals(redirectUri)) {
+			throw new InvalidGrantException();
+		}
+
+		if (!PkceValidator.validate(
+				codeVerifier, codeData.getCodeChallenge(), codeData.getCodeChallengeMethod())) {
+			throw new InvalidGrantException();
+		}
+
+		ClientEntity client =
+				clientRepository
+						.findByClientIdWithRedirectUris(clientId)
+						.orElseThrow(InvalidClientException::new);
+
+		return tokenGenerator.execute(
+				codeData.getMemberId(), client.getClientType().name(), client.getClientId());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/AuthenticationTokenGenerator.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/AuthenticationTokenGenerator.java
@@ -26,6 +26,17 @@ public class AuthenticationTokenGenerator {
 				tokenResolver.getExpiredDateByRefreshToken(refreshToken));
 	}
 
+	public TokenModel execute(final Long memberId, final String clientType, final String clientId) {
+		String accessToken = tokenProvider.createAccessToken(memberId);
+		String refreshToken = tokenProvider.createRefreshToken(memberId, clientType, clientId);
+
+		return tokenModelConverter.from(
+				accessToken,
+				tokenResolver.getExpiredDateByAccessToken(accessToken),
+				refreshToken,
+				tokenResolver.getExpiredDateByRefreshToken(refreshToken));
+	}
+
 	public TokenModel execute(final Long memberId, Set<String> authorities) {
 		String accessToken = tokenProvider.createAccessToken(memberId, authorities);
 		String refreshToken = tokenProvider.createRefreshToken(memberId, authorities);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/LoginRateLimiter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/LoginRateLimiter.java
@@ -1,0 +1,83 @@
+package com.blackcompany.eeos.auth.application.support;
+
+import com.blackcompany.eeos.auth.application.exception.RateLimitExceededException;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginRateLimiter {
+
+	private static final String IP_KEY_PREFIX = "login_fail:ip:";
+	private static final String ACCOUNT_KEY_PREFIX = "login_fail:account:";
+	private static final int MAX_IP_ATTEMPTS_PER_MINUTE = 20;
+	private static final int MAX_ACCOUNT_ATTEMPTS = 5;
+	private static final long IP_WINDOW_SECONDS = 60;
+	private static final long ACCOUNT_LOCKOUT_SECONDS = 300;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void checkRateLimit(String ip, String email) {
+		try {
+			checkIpLimit(ip);
+			checkAccountLockout(email);
+		} catch (RateLimitExceededException e) {
+			throw e;
+		} catch (Exception e) {
+			log.warn("Rate limiter Redis error, allowing request: {}", e.getMessage());
+		}
+	}
+
+	public void recordFailure(String ip, String email) {
+		try {
+			incrementCounter(IP_KEY_PREFIX + ip, IP_WINDOW_SECONDS);
+			incrementCounter(ACCOUNT_KEY_PREFIX + email, ACCOUNT_LOCKOUT_SECONDS);
+		} catch (Exception e) {
+			log.warn("Failed to record login failure: {}", e.getMessage());
+		}
+	}
+
+	public void resetAccountCounter(String email) {
+		try {
+			redisTemplate.delete(ACCOUNT_KEY_PREFIX + email);
+		} catch (Exception e) {
+			log.warn("Failed to reset account counter: {}", e.getMessage());
+		}
+	}
+
+	private void checkIpLimit(String ip) {
+		Long count = getCounter(IP_KEY_PREFIX + ip);
+		if (count != null && count >= MAX_IP_ATTEMPTS_PER_MINUTE) {
+			throw new RateLimitExceededException();
+		}
+	}
+
+	private void checkAccountLockout(String email) {
+		Long count = getCounter(ACCOUNT_KEY_PREFIX + email);
+		if (count != null && count >= MAX_ACCOUNT_ATTEMPTS) {
+			throw new RateLimitExceededException();
+		}
+	}
+
+	private void incrementCounter(String key, long ttlSeconds) {
+		Long count = redisTemplate.opsForValue().increment(key);
+		if (count != null && count == 1) {
+			redisTemplate.expire(key, ttlSeconds, TimeUnit.SECONDS);
+		}
+	}
+
+	private Long getCounter(String key) {
+		Object value = redisTemplate.opsForValue().get(key);
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof Number) {
+			return ((Number) value).longValue();
+		}
+		return Long.parseLong(value.toString());
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/AuthorizationCodeRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/AuthorizationCodeRepository.java
@@ -1,0 +1,45 @@
+package com.blackcompany.eeos.auth.persistence;
+
+import com.blackcompany.eeos.auth.application.domain.AuthorizationCodeData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthorizationCodeRepository {
+
+	private static final String KEY_PREFIX = "auth_code:";
+	private static final long TTL_SECONDS = 60;
+	private static final int CODE_BYTE_LENGTH = 16;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public String save(AuthorizationCodeData data) {
+		String code = generateCode();
+		redisTemplate.opsForValue().set(KEY_PREFIX + code, data, TTL_SECONDS, TimeUnit.SECONDS);
+		return code;
+	}
+
+	public Optional<AuthorizationCodeData> findAndDelete(String code) {
+		String key = KEY_PREFIX + code;
+		Object value = redisTemplate.opsForValue().get(key);
+		if (value == null) {
+			return Optional.empty();
+		}
+		redisTemplate.delete(key);
+		return Optional.of(objectMapper.convertValue(value, AuthorizationCodeData.class));
+	}
+
+	private String generateCode() {
+		byte[] bytes = new byte[CODE_BYTE_LENGTH];
+		new SecureRandom().nextBytes(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/client/ClientEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/client/ClientEntity.java
@@ -1,0 +1,62 @@
+package com.blackcompany.eeos.auth.persistence.client;
+
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.common.persistence.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder(toBuilder = true)
+@Entity
+@Table(name = ClientEntity.ENTITY_PREFIX)
+public class ClientEntity extends BaseEntity {
+	public static final String ENTITY_PREFIX = "oauth_client";
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = ENTITY_PREFIX + "_id", nullable = false)
+	private Long id;
+
+	@Column(name = ENTITY_PREFIX + "_client_id", nullable = false, unique = true, length = 36)
+	private String clientId;
+
+	@Column(name = ENTITY_PREFIX + "_client_secret")
+	private String clientSecret;
+
+	@Column(name = ENTITY_PREFIX + "_client_name", nullable = false, length = 100)
+	private String clientName;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = ENTITY_PREFIX + "_client_type", nullable = false, length = 10)
+	private ClientType clientType;
+
+	@OneToMany(mappedBy = "client", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<ClientRedirectUriEntity> redirectUris = new ArrayList<>();
+
+	public void addRedirectUri(String uri) {
+		redirectUris.add(ClientRedirectUriEntity.builder().client(this).redirectUri(uri).build());
+	}
+
+	public boolean hasRedirectUri(String uri) {
+		return redirectUris.stream().anyMatch(r -> r.getRedirectUri().equals(uri));
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/client/ClientRedirectUriEntity.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/client/ClientRedirectUriEntity.java
@@ -1,0 +1,37 @@
+package com.blackcompany.eeos.auth.persistence.client;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "oauth_client_redirect_uri")
+public class ClientRedirectUriEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "redirect_uri_id", nullable = false)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "oauth_client_id", nullable = false)
+	private ClientEntity client;
+
+	@Column(name = "redirect_uri", nullable = false, length = 512)
+	private String redirectUri;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/client/ClientRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/client/ClientRepository.java
@@ -1,0 +1,11 @@
+package com.blackcompany.eeos.auth.persistence.client;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ClientRepository extends JpaRepository<ClientEntity, Long> {
+
+	@Query("SELECT c FROM ClientEntity c LEFT JOIN FETCH c.redirectUris WHERE c.clientId = :clientId")
+	Optional<ClientEntity> findByClientIdWithRedirectUris(String clientId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -96,8 +96,9 @@ public class AuthController implements AuthApi {
 		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
+	@Deprecated
 	@Override
-	@PostMapping("/login")
+	@PostMapping("/login/legacy")
 	public ApiResponse<SuccessBody<TokenResponse>> login(
 			@RequestBody EEOSLoginRequest request, HttpServletResponse httpResponse) {
 		TokenModel tokenModel = loginUsecase.login(request.getId(), request.getPassword());

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.auth.presentation.controller;
 
 import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
 import com.blackcompany.eeos.auth.application.dto.request.AdditionalInfoApplicationCommand;
 import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
@@ -12,6 +13,7 @@ import com.blackcompany.eeos.auth.presentation.docs.AuthApi;
 import com.blackcompany.eeos.auth.presentation.dto.AdditionalInfoRequest;
 import com.blackcompany.eeos.auth.presentation.dto.EeosSignUpRequest;
 import com.blackcompany.eeos.auth.presentation.support.AuthConstants;
+import com.blackcompany.eeos.auth.presentation.support.AuthCookieManager;
 import com.blackcompany.eeos.auth.presentation.support.Member;
 import com.blackcompany.eeos.auth.presentation.support.TokenExtractor;
 import com.blackcompany.eeos.auth.presentation.support.VerificationId;
@@ -42,11 +44,13 @@ public class AuthController implements AuthApi {
 	private final ReissueUsecase reissueUsecase;
 	private final TokenExtractor tokenExtractor;
 	private final CookieManager cookieManager;
+	private final AuthCookieManager authCookieManager;
 	private final TokenResponseConverter tokenResponseConverter;
 	private final LogOutUsecase logOutUsecase;
 	private final WithDrawUsecase withDrawUsecase;
 	private final OAuthSignUpUseCase oAuthSignUpUseCase;
 	private final EeosSignUpUseCase eeosSignUpUseCase;
+	private final TokenResolver tokenResolver;
 
 	public AuthController(
 			LoginUsecase loginUsecase,
@@ -54,21 +58,26 @@ public class AuthController implements AuthApi {
 			@Qualifier("cookie") TokenExtractor tokenExtractor,
 			TokenResponseConverter tokenResponseConverter,
 			CookieManager cookieManager,
+			AuthCookieManager authCookieManager,
 			LogOutUsecase logOutUsecase,
 			WithDrawUsecase withDrawUsecase,
 			OAuthSignUpUseCase oAuthSignUpUseCase,
-			EeosSignUpUseCase eeosSignUpUseCase) {
+			EeosSignUpUseCase eeosSignUpUseCase,
+			TokenResolver tokenResolver) {
 		this.loginUsecase = loginUsecase;
 		this.reissueUsecase = reissueUsecase;
 		this.tokenExtractor = tokenExtractor;
 		this.tokenResponseConverter = tokenResponseConverter;
 		this.cookieManager = cookieManager;
+		this.authCookieManager = authCookieManager;
 		this.logOutUsecase = logOutUsecase;
 		this.withDrawUsecase = withDrawUsecase;
 		this.oAuthSignUpUseCase = oAuthSignUpUseCase;
 		this.eeosSignUpUseCase = eeosSignUpUseCase;
+		this.tokenResolver = tokenResolver;
 	}
 
+	@Deprecated
 	@Override
 	@PostMapping("/login/{oauthServerType}")
 	public ApiResponse<SuccessBody<TokenResponse>> login(
@@ -84,13 +93,7 @@ public class AuthController implements AuthApi {
 
 		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
 
-		// 마이그레이션 필요 체크 - 임시 코드
-		HttpHeaders headers = new HttpHeaders();
-		if ("slack".equals(oauthServerType)) {
-			headers.add("Migration-Required", "true");
-		}
-
-		return ApiResponseGenerator.success(response, HttpStatus.CREATED, headers, MessageCode.CREATE);
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
 	@Override
@@ -107,9 +110,16 @@ public class AuthController implements AuthApi {
 	public ApiResponse<SuccessBody<TokenResponse>> reissue(
 			HttpServletRequest request, HttpServletResponse httpResponse) {
 		String token = tokenExtractor.extract(request);
-		TokenModel tokenModel = reissueUsecase.execute(token);
-		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
+		String clientType = tokenResolver.getClientTypeByRefreshToken(token);
 
+		TokenModel tokenModel = reissueUsecase.execute(token);
+
+		if ("WEB".equals(clientType)) {
+			setWebCookies(tokenModel, httpResponse);
+		}
+
+		TokenResponse response =
+				tokenResponseConverter.from(tokenModel.getAccessToken(), tokenModel.getAccessExpiredTime());
 		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
@@ -118,7 +128,13 @@ public class AuthController implements AuthApi {
 	public ApiResponse<SuccessBody<Void>> logout(
 			HttpServletRequest request, HttpServletResponse httpResponse, @Member Long memberId) {
 		String token = tokenExtractor.extract(request);
+		String clientType = tokenResolver.getClientTypeByRefreshToken(token);
+
 		logOutUsecase.logOut(token, memberId);
+
+		if ("WEB".equals(clientType)) {
+			deleteWebCookies(httpResponse);
+		}
 		deleteTokenResponse(httpResponse);
 
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.DELETE);
@@ -178,6 +194,20 @@ public class AuthController implements AuthApi {
 		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
 		return response;
+	}
+
+	private void setWebCookies(TokenModel tokenModel, HttpServletResponse httpResponse) {
+		ResponseCookie atCookie = authCookieManager.setAccessTokenCookie(tokenModel.getAccessToken());
+		ResponseCookie rtCookie = authCookieManager.setRefreshTokenCookie(tokenModel.getRefreshToken());
+		httpResponse.addHeader(HttpHeaders.SET_COOKIE, atCookie.toString());
+		httpResponse.addHeader(HttpHeaders.SET_COOKIE, rtCookie.toString());
+	}
+
+	private void deleteWebCookies(HttpServletResponse httpResponse) {
+		ResponseCookie atCookie = authCookieManager.deleteAccessTokenCookie();
+		ResponseCookie rtCookie = authCookieManager.deleteRefreshTokenCookie();
+		httpResponse.addHeader(HttpHeaders.SET_COOKIE, atCookie.toString());
+		httpResponse.addHeader(HttpHeaders.SET_COOKIE, rtCookie.toString());
 	}
 
 	private void deleteTokenResponse(HttpServletResponse httpServletResponse) {

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -4,9 +4,7 @@ import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
 import com.blackcompany.eeos.auth.application.dto.request.AdditionalInfoApplicationCommand;
-import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
-import com.blackcompany.eeos.auth.application.dto.request.OAuthLoginRequestCommand;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
 import com.blackcompany.eeos.auth.application.usecase.*;
 import com.blackcompany.eeos.auth.presentation.docs.AuthApi;
@@ -30,11 +28,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -75,35 +71,6 @@ public class AuthController implements AuthApi {
 		this.oAuthSignUpUseCase = oAuthSignUpUseCase;
 		this.eeosSignUpUseCase = eeosSignUpUseCase;
 		this.tokenResolver = tokenResolver;
-	}
-
-	@Deprecated
-	@Override
-	@PostMapping("/login/{oauthServerType}")
-	public ApiResponse<SuccessBody<TokenResponse>> login(
-			@PathVariable String oauthServerType,
-			@RequestParam("code") String code,
-			@RequestParam("redirect_uri") String uri,
-			HttpServletResponse httpResponse) {
-		String formatUri = uri.trim().replaceAll("[\n\r\t ]", "");
-
-		OAuthLoginRequestCommand command =
-				new OAuthLoginRequestCommand(oauthServerType, code, formatUri);
-		TokenModel tokenModel = loginUsecase.login(command);
-
-		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
-
-		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
-	}
-
-	@Deprecated
-	@Override
-	@PostMapping("/login/legacy")
-	public ApiResponse<SuccessBody<TokenResponse>> login(
-			@RequestBody EEOSLoginRequest request, HttpServletResponse httpResponse) {
-		TokenModel tokenModel = loginUsecase.login(request.getId(), request.getPassword());
-		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
-		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/ClientController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/ClientController.java
@@ -1,0 +1,40 @@
+package com.blackcompany.eeos.auth.presentation.controller;
+
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.dto.request.ClientRegistrationRequest;
+import com.blackcompany.eeos.auth.application.dto.response.ClientRegistrationResponse;
+import com.blackcompany.eeos.auth.application.service.ClientService;
+import com.blackcompany.eeos.auth.presentation.docs.ClientApi;
+import com.blackcompany.eeos.auth.presentation.support.Member;
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.response.MessageCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/clients")
+@RequiredArgsConstructor
+public class ClientController implements ClientApi {
+
+	private final ClientService clientService;
+
+	@Override
+	@PostMapping
+	public ApiResponse<SuccessBody<ClientRegistrationResponse>> register(
+			@RequestBody ClientRegistrationRequest request, @Member Long memberId) {
+		ClientType clientType = ClientType.valueOf(request.getClientType().toUpperCase());
+		var result =
+				clientService.register(request.getClientName(), clientType, request.getRedirectUris());
+
+		ClientRegistrationResponse response =
+				new ClientRegistrationResponse(result.clientId(), result.clientSecret());
+
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
@@ -1,0 +1,218 @@
+package com.blackcompany.eeos.auth.presentation.controller;
+
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.exception.InvalidClientException;
+import com.blackcompany.eeos.auth.application.exception.InvalidRedirectUriException;
+import com.blackcompany.eeos.auth.application.service.ClientService;
+import com.blackcompany.eeos.auth.application.service.OAuth2LoginService;
+import com.blackcompany.eeos.auth.application.service.TokenExchangeService;
+import com.blackcompany.eeos.auth.presentation.docs.OAuth2Api;
+import com.blackcompany.eeos.auth.presentation.support.AuthCookieManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class OAuth2Controller implements OAuth2Api {
+
+	private final ClientService clientService;
+	private final OAuth2LoginService oAuth2LoginService;
+	private final TokenExchangeService tokenExchangeService;
+	private final AuthCookieManager cookieManager;
+
+	@Value("${auth.login-page-url:http://localhost:3000/login}")
+	private String loginPageUrl;
+
+	@Override
+	@GetMapping("/authorize")
+	public ResponseEntity<Void> authorize(
+			@RequestParam("client_id") String clientId,
+			@RequestParam("redirect_uri") String redirectUri,
+			@RequestParam("response_type") String responseType,
+			@RequestParam("state") String state,
+			@RequestParam(value = "code_challenge", required = false) String codeChallenge,
+			@RequestParam(value = "code_challenge_method", required = false) String codeChallengeMethod) {
+
+		if (!"code".equals(responseType)) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		var client = clientService.findAndValidateRedirectUri(clientId, redirectUri);
+
+		if (client.getClientType() == ClientType.APP && codeChallenge == null) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		String location =
+				UriComponentsBuilder.fromUriString(loginPageUrl)
+						.queryParam("client_id", clientId)
+						.queryParam("redirect_uri", redirectUri)
+						.queryParam("state", state)
+						.queryParamIfPresent("code_challenge", java.util.Optional.ofNullable(codeChallenge))
+						.queryParamIfPresent(
+								"code_challenge_method", java.util.Optional.ofNullable(codeChallengeMethod))
+						.build()
+						.toUriString();
+
+		return ResponseEntity.status(HttpStatus.FOUND).header(HttpHeaders.LOCATION, location).build();
+	}
+
+	@Override
+	@PostMapping("/login/oauth2")
+	public ResponseEntity<Void> loginOAuth2(
+			@RequestParam("client_id") String clientId,
+			@RequestParam("redirect_uri") String redirectUri,
+			@RequestParam("state") String state,
+			@RequestParam("email") String email,
+			@RequestParam("password") String password,
+			@RequestParam(value = "code_challenge", required = false) String codeChallenge,
+			@RequestParam(value = "code_challenge_method", required = false) String codeChallengeMethod,
+			HttpServletRequest request,
+			HttpServletResponse response) {
+
+		var client = validateClientOrBadRequest(clientId, redirectUri);
+		if (client == null) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		String ip = request.getRemoteAddr();
+
+		try {
+			if (client.getClientType() == ClientType.WEB) {
+				return handleWebLogin(clientId, redirectUri, state, email, password, ip, response);
+			} else {
+				return handleAppLogin(
+						clientId, redirectUri, state, email, password, ip, codeChallenge, codeChallengeMethod);
+			}
+		} catch (Exception e) {
+			return redirectToLoginPageWithError(
+					clientId, redirectUri, state, codeChallenge, codeChallengeMethod);
+		}
+	}
+
+	@Override
+	@PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	public ResponseEntity<Map<String, Object>> token(
+			@RequestParam("grant_type") String grantType,
+			@RequestParam("code") String code,
+			@RequestParam("code_verifier") String codeVerifier,
+			@RequestParam("redirect_uri") String redirectUri,
+			@RequestParam("client_id") String clientId) {
+
+		if (!"authorization_code".equals(grantType)) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		TokenModel tokenModel =
+				tokenExchangeService.exchange(code, codeVerifier, redirectUri, clientId);
+
+		Map<String, Object> body = new HashMap<>();
+		body.put("access_token", tokenModel.getAccessToken());
+		body.put("refresh_token", tokenModel.getRefreshToken());
+		body.put("token_type", "Bearer");
+		body.put("expires_in", (tokenModel.getAccessExpiredTime() - System.currentTimeMillis()) / 1000);
+
+		return ResponseEntity.ok(body);
+	}
+
+	private com.blackcompany.eeos.auth.persistence.client.ClientEntity validateClientOrBadRequest(
+			String clientId, String redirectUri) {
+		try {
+			return clientService.findAndValidateRedirectUri(clientId, redirectUri);
+		} catch (InvalidClientException | InvalidRedirectUriException e) {
+			return null;
+		}
+	}
+
+	private ResponseEntity<Void> handleWebLogin(
+			String clientId,
+			String redirectUri,
+			String state,
+			String email,
+			String password,
+			String ip,
+			HttpServletResponse response) {
+		TokenModel tokenModel =
+				oAuth2LoginService.loginForWeb(clientId, redirectUri, email, password, ip);
+
+		ResponseCookie atCookie = cookieManager.setAccessTokenCookie(tokenModel.getAccessToken());
+		ResponseCookie rtCookie = cookieManager.setRefreshTokenCookie(tokenModel.getRefreshToken());
+		response.addHeader(HttpHeaders.SET_COOKIE, atCookie.toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, rtCookie.toString());
+
+		String location =
+				UriComponentsBuilder.fromUriString(redirectUri)
+						.queryParam("state", state)
+						.build()
+						.toUriString();
+
+		return ResponseEntity.status(HttpStatus.SEE_OTHER)
+				.header(HttpHeaders.LOCATION, location)
+				.build();
+	}
+
+	private ResponseEntity<Void> handleAppLogin(
+			String clientId,
+			String redirectUri,
+			String state,
+			String email,
+			String password,
+			String ip,
+			String codeChallenge,
+			String codeChallengeMethod) {
+		String code =
+				oAuth2LoginService.loginForApp(
+						clientId, redirectUri, email, password, ip, codeChallenge, codeChallengeMethod);
+
+		String location =
+				UriComponentsBuilder.fromUriString(redirectUri)
+						.queryParam("code", code)
+						.queryParam("state", state)
+						.build()
+						.toUriString();
+
+		return ResponseEntity.status(HttpStatus.SEE_OTHER)
+				.header(HttpHeaders.LOCATION, location)
+				.build();
+	}
+
+	private ResponseEntity<Void> redirectToLoginPageWithError(
+			String clientId,
+			String redirectUri,
+			String state,
+			String codeChallenge,
+			String codeChallengeMethod) {
+		String location =
+				UriComponentsBuilder.fromUriString(loginPageUrl)
+						.queryParam("client_id", clientId)
+						.queryParam("redirect_uri", redirectUri)
+						.queryParam("state", state)
+						.queryParamIfPresent("code_challenge", java.util.Optional.ofNullable(codeChallenge))
+						.queryParamIfPresent(
+								"code_challenge_method", java.util.Optional.ofNullable(codeChallengeMethod))
+						.queryParam("error", "invalid_credentials")
+						.build()
+						.toUriString();
+
+		return ResponseEntity.status(HttpStatus.SEE_OTHER)
+				.header(HttpHeaders.LOCATION, location)
+				.build();
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
@@ -75,7 +75,7 @@ public class OAuth2Controller implements OAuth2Api {
 	}
 
 	@Override
-	@PostMapping("/login/oauth2")
+	@PostMapping("/login")
 	public ResponseEntity<Void> loginOAuth2(
 			@RequestParam("client_id") String clientId,
 			@RequestParam("redirect_uri") String redirectUri,

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
@@ -76,7 +76,7 @@ public class OAuth2Controller implements OAuth2Api {
 
 	@Override
 	@PostMapping("/login")
-	public ResponseEntity<Void> loginOAuth2(
+	public ResponseEntity<Void> login(
 			@RequestParam("client_id") String clientId,
 			@RequestParam("redirect_uri") String redirectUri,
 			@RequestParam("state") String state,

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -1,6 +1,5 @@
 package com.blackcompany.eeos.auth.presentation.docs;
 
-import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
 import com.blackcompany.eeos.auth.presentation.dto.EeosSignUpRequest;
 import com.blackcompany.eeos.auth.presentation.support.Member;
@@ -15,40 +14,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "인증", description = "인증 관련 API")
 public interface AuthApi {
-	@Deprecated
-	@Operation(
-			summary = "[Deprecated] OAuth 로그인",
-			description =
-					"레거시 OAuth 로그인 엔드포인트. /api/auth/login/oauth2를 사용하세요. "
-							+ "PathVariable에 담긴 redirect_url, code를 받아 액세스 토큰과 리프레시 토큰을 발급한다.")
-	ApiResponse<SuccessBody<TokenResponse>> login(
-			@Parameter(description = "OAuth 서버 타입 (예: slack)", required = true) @PathVariable
-					String oauthServerType,
-			@Parameter(description = "OAuth 인증 코드", required = true) @RequestParam("code") String code,
-			@Parameter(description = "리다이렉트 URI", required = true) @RequestParam("redirect_uri")
-					String uri,
-			HttpServletResponse httpResponse);
-
-	@Operation(summary = "일반 로그인", description = "사용자가 id와 password를 이용하여 로그인한다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-				responseCode = "200",
-				description = "로그인 성공"),
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-				responseCode = "401",
-				description = "4008: ID 또는 비밀번호가 일치하지 않습니다",
-				content = @Content)
-	})
-	ApiResponse<SuccessBody<TokenResponse>> login(
-			@Parameter(description = "로그인 요청 정보", required = true) @RequestBody EEOSLoginRequest request,
-			HttpServletResponse httpResponse);
-
 	@Operation(summary = "회원가입", description = "id, password, 기수, 성함, 활동상태로 회원가입하고 토큰을 반환한다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -21,9 +21,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "인증", description = "인증 관련 API")
 public interface AuthApi {
+	@Deprecated
 	@Operation(
-			summary = "OAuth 로그인",
-			description = "PathVariable에 담긴 redirect_url, code를 받아 액세스 토큰과 리프레시 토큰을 발급한다.")
+			summary = "[Deprecated] OAuth 로그인",
+			description =
+					"레거시 OAuth 로그인 엔드포인트. /api/auth/login/oauth2를 사용하세요. "
+							+ "PathVariable에 담긴 redirect_url, code를 받아 액세스 토큰과 리프레시 토큰을 발급한다.")
 	ApiResponse<SuccessBody<TokenResponse>> login(
 			@Parameter(description = "OAuth 서버 타입 (예: slack)", required = true) @PathVariable
 					String oauthServerType,
@@ -81,15 +84,36 @@ public interface AuthApi {
 
 	@Operation(
 			summary = "토큰 재발급",
-			description = "쿠키에 담긴 사용자 토큰을 이용하여 리프레시 토큰을 반환한다.",
+			description =
+					"리프레시 토큰을 이용하여 새로운 AT/RT를 발급한다. "
+							+ "Web 클라이언트: AT/RT 쿠키를 재설정한다. "
+							+ "App 클라이언트: 응답 바디에 토큰을 반환한다.",
 			security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "201",
+				description = "토큰 재발급 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "401",
+				description = "4003: 만료된 토큰 / 4004: 블랙리스트 등록된 토큰",
+				content = @Content)
+	})
 	ApiResponse<SuccessBody<TokenResponse>> reissue(
 			HttpServletRequest request, HttpServletResponse httpResponse);
 
 	@Operation(
 			summary = "로그아웃",
-			description = "쿠키에 담긴 리프레시 토큰을 이용하여 로그아웃한다.",
+			description = "리프레시 토큰을 블랙리스트에 등록하여 로그아웃한다. " + "Web 클라이언트: AT/RT 쿠키도 함께 삭제한다.",
 			security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "200",
+				description = "로그아웃 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "401",
+				description = "4003: 인증 실패",
+				content = @Content)
+	})
 	ApiResponse<SuccessBody<Void>> logout(
 			HttpServletRequest request,
 			HttpServletResponse httpResponse,

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/ClientApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/ClientApi.java
@@ -27,14 +27,13 @@ public interface ClientApi {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "400",
 				description =
-						"요청 검증 실패\n\n"
-								+ "| 코드 | 메시지 |\n"
+						"| 코드 | 메시지 |\n"
 								+ "|------|--------|\n"
-								+ "| 4011 | redirectUris가 비어있거나 10개 초과 또는 512자 초과 |",
+								+ "| 4015 | redirectUris가 비어있거나 10개 초과 또는 512자 초과 |",
 				content = @Content),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "403",
-				description = "관리자 권한 필요",
+				description = "| 코드 | 메시지 |\n" + "|------|--------|\n" + "| 403 | 관리자 권한 필요 |",
 				content = @Content)
 	})
 	ApiResponse<SuccessBody<ClientRegistrationResponse>> register(

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/ClientApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/ClientApi.java
@@ -1,0 +1,44 @@
+package com.blackcompany.eeos.auth.presentation.docs;
+
+import com.blackcompany.eeos.auth.application.dto.request.ClientRegistrationRequest;
+import com.blackcompany.eeos.auth.application.dto.response.ClientRegistrationResponse;
+import com.blackcompany.eeos.auth.presentation.support.Member;
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "클라이언트 관리", description = "OAuth2 클라이언트 등록 API")
+public interface ClientApi {
+
+	@Operation(
+			summary = "클라이언트 등록",
+			description = "OAuth2 클라이언트를 등록한다. WEB은 client_secret이 발급되고, APP은 발급되지 않는다. 관리자만 호출 가능.",
+			security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "201",
+				description = "클라이언트 등록 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "400",
+				description =
+						"요청 검증 실패\n\n"
+								+ "| 코드 | 메시지 |\n"
+								+ "|------|--------|\n"
+								+ "| 4011 | redirectUris가 비어있거나 10개 초과 또는 512자 초과 |",
+				content = @Content),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "403",
+				description = "관리자 권한 필요",
+				content = @Content)
+	})
+	ApiResponse<SuccessBody<ClientRegistrationResponse>> register(
+			@Parameter(description = "클라이언트 등록 요청 정보", required = true) @RequestBody
+					ClientRegistrationRequest request,
+			@Parameter(hidden = true) @Member Long memberId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
@@ -58,7 +58,7 @@ public interface OAuth2Api {
 				description = "4290: 로그인 시도 횟수 초과",
 				content = @Content)
 	})
-	ResponseEntity<Void> loginOAuth2(
+	ResponseEntity<Void> login(
 			@Parameter(description = "클라이언트 ID", required = true) String clientId,
 			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
 			@Parameter(description = "CSRF 상태값", required = true) String state,

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
@@ -1,0 +1,99 @@
+package com.blackcompany.eeos.auth.presentation.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "OAuth2 인증", description = "Web/App 분리 인증 API")
+public interface OAuth2Api {
+
+	@Operation(
+			summary = "인증 진입점",
+			description =
+					"client_id, redirect_uri를 검증하고 로그인 페이지로 리다이렉트한다. " + "APP 클라이언트는 code_challenge가 필수이다.")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "302",
+				description = "로그인 페이지로 리다이렉트"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "400",
+				description =
+						"요청 검증 실패\n\n"
+								+ "| 코드 | 메시지 |\n"
+								+ "|------|--------|\n"
+								+ "| 4010 | 유효하지 않은 클라이언트 |\n"
+								+ "| 4011 | 등록되지 않은 redirect URI |",
+				content = @Content)
+	})
+	ResponseEntity<Void> authorize(
+			@Parameter(description = "클라이언트 ID", required = true) String clientId,
+			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
+			@Parameter(description = "응답 타입 (code만 지원)", required = true) String responseType,
+			@Parameter(description = "CSRF 방지용 상태값", required = true) String state,
+			@Parameter(description = "PKCE code_challenge (APP 필수)") String codeChallenge,
+			@Parameter(description = "PKCE 방식 (S256만 지원)") String codeChallengeMethod);
+
+	@Operation(
+			summary = "OAuth2 로그인",
+			description =
+					"credentials를 검증하고 clientType에 따라 분기한다. "
+							+ "WEB: 쿠키에 AT/RT 설정 후 303 redirect. "
+							+ "APP: authorization_code 발급 후 303 redirect.")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "303",
+				description = "인증 성공 후 redirect_uri로 리다이렉트"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "400",
+				description = "client_id 또는 redirect_uri 검증 실패",
+				content = @Content),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "429",
+				description = "4290: 로그인 시도 횟수 초과",
+				content = @Content)
+	})
+	ResponseEntity<Void> loginOAuth2(
+			@Parameter(description = "클라이언트 ID", required = true) String clientId,
+			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
+			@Parameter(description = "CSRF 상태값", required = true) String state,
+			@Parameter(description = "이메일", required = true) String email,
+			@Parameter(description = "비밀번호", required = true) String password,
+			@Parameter(description = "PKCE code_challenge") String codeChallenge,
+			@Parameter(description = "PKCE 방식") String codeChallengeMethod,
+			HttpServletRequest request,
+			HttpServletResponse response);
+
+	@Operation(
+			summary = "토큰 교환",
+			description =
+					"authorization_code를 AT/RT로 교환한다. "
+							+ "Content-Type: application/x-www-form-urlencoded. "
+							+ "PKCE code_verifier 검증 필수.")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "200",
+				description = "토큰 발급 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "400",
+				description =
+						"교환 실패\n\n"
+								+ "| 코드 | 메시지 |\n"
+								+ "|------|--------|\n"
+								+ "| 4010 | client_id 불일치 |\n"
+								+ "| 4012 | code 만료/사용됨/PKCE 실패/redirect_uri 불일치 |",
+				content = @Content)
+	})
+	ResponseEntity<Map<String, Object>> token(
+			@Parameter(description = "grant_type (authorization_code만 지원)", required = true)
+					String grantType,
+			@Parameter(description = "authorization code", required = true) String code,
+			@Parameter(description = "PKCE code_verifier", required = true) String codeVerifier,
+			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
+			@Parameter(description = "클라이언트 ID", required = true) String clientId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
@@ -24,11 +24,11 @@ public interface OAuth2Api {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "400",
 				description =
-						"요청 검증 실패\n\n"
-								+ "| 코드 | 메시지 |\n"
+						"| 코드 | 메시지 |\n"
 								+ "|------|--------|\n"
-								+ "| 4010 | 유효하지 않은 클라이언트 |\n"
-								+ "| 4011 | 등록되지 않은 redirect URI |",
+								+ "| 4014 | 유효하지 않은 클라이언트 |\n"
+								+ "| 4015 | 등록되지 않은 redirect URI |\n"
+								+ "| 4015 | redirect_uri 불일치 시 redirect 없이 즉시 반환 |",
 				content = @Content)
 	})
 	ResponseEntity<Void> authorize(
@@ -43,34 +43,39 @@ public interface OAuth2Api {
 			summary = "OAuth2 로그인",
 			description =
 					"credentials를 검증하고 clientType에 따라 분기한다. "
-							+ "WEB: 쿠키에 AT/RT 설정 후 303 redirect. "
-							+ "APP: authorization_code 발급 후 303 redirect.")
+							+ "WEB: eeos_access_token / eeos_refresh_token 쿠키 설정 후 303 redirect. "
+							+ "APP: authorization_code 발급 후 303 redirect. "
+							+ "credentials 실패 시 로그인 페이지로 303 redirect (error=invalid_credentials).")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "303",
 				description = "인증 성공 후 redirect_uri로 리다이렉트"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "400",
-				description = "client_id 또는 redirect_uri 검증 실패",
+				description =
+						"| 코드 | 메시지 |\n"
+								+ "|------|--------|\n"
+								+ "| 4014 | 유효하지 않은 클라이언트 |\n"
+								+ "| 4015 | 등록되지 않은 redirect URI |",
 				content = @Content),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "429",
-				description = "4290: 로그인 시도 횟수 초과",
+				description = "| 코드 | 메시지 |\n" + "|------|--------|\n" + "| 4290 | 로그인 시도 횟수를 초과했습니다 |",
 				content = @Content)
 	})
 	ResponseEntity<Void> login(
 			@Parameter(description = "클라이언트 ID", required = true) String clientId,
 			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
-			@Parameter(description = "CSRF 상태값", required = true) String state,
+			@Parameter(description = "CSRF 방지용 상태값", required = true) String state,
 			@Parameter(description = "이메일", required = true) String email,
 			@Parameter(description = "비밀번호", required = true) String password,
-			@Parameter(description = "PKCE code_challenge") String codeChallenge,
-			@Parameter(description = "PKCE 방식") String codeChallengeMethod,
+			@Parameter(description = "PKCE code_challenge (APP 필수)") String codeChallenge,
+			@Parameter(description = "PKCE 방식 (S256만 지원, APP 필수)") String codeChallengeMethod,
 			HttpServletRequest request,
 			HttpServletResponse response);
 
 	@Operation(
-			summary = "토큰 교환",
+			summary = "토큰 교환 (App 전용)",
 			description =
 					"authorization_code를 AT/RT로 교환한다. "
 							+ "Content-Type: application/x-www-form-urlencoded. "
@@ -82,11 +87,10 @@ public interface OAuth2Api {
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "400",
 				description =
-						"교환 실패\n\n"
-								+ "| 코드 | 메시지 |\n"
+						"| 코드 | 메시지 |\n"
 								+ "|------|--------|\n"
-								+ "| 4010 | client_id 불일치 |\n"
-								+ "| 4012 | code 만료/사용됨/PKCE 실패/redirect_uri 불일치 |",
+								+ "| 4014 | 유효하지 않은 클라이언트 (client_id 불일치) |\n"
+								+ "| 4016 | 유효하지 않은 인가 코드 (만료/재사용/PKCE 실패/redirect_uri 불일치) |",
 				content = @Content)
 	})
 	ResponseEntity<Map<String, Object>> token(
@@ -94,6 +98,6 @@ public interface OAuth2Api {
 					String grantType,
 			@Parameter(description = "authorization code", required = true) String code,
 			@Parameter(description = "PKCE code_verifier", required = true) String codeVerifier,
-			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
+			@Parameter(description = "리다이렉트 URI (인가 요청 시와 동일해야 함)", required = true) String redirectUri,
 			@Parameter(description = "클라이언트 ID", required = true) String clientId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthConstants.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthConstants.java
@@ -2,4 +2,6 @@ package com.blackcompany.eeos.auth.presentation.support;
 
 public class AuthConstants {
 	public static final String TOKEN_KEY = "eeos_token";
+	public static final String ACCESS_TOKEN_KEY = "eeos_access_token";
+	public static final String REFRESH_TOKEN_KEY = "eeos_refresh_token";
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/support/AuthCookieManager.java
@@ -15,7 +15,7 @@ public class AuthCookieManager implements CookieManager {
 
 	private static final Boolean HTTP_ONLY = true;
 	private static final Boolean SECURE = true;
-	private static final String SAMESITE = "None";
+	private static final String SAMESITE = "Lax";
 	private static final Long EXPIRATION = 0L;
 
 	@Value("${token.cookie.domain}")
@@ -24,8 +24,55 @@ public class AuthCookieManager implements CookieManager {
 	@Value("${token.cookie.path}")
 	private String path;
 
+	@Value("${security.jwt.access.validTime}")
+	private Long accessValidTime;
+
 	@Value("${security.jwt.refresh.validTime}")
 	private Long validTime;
+
+	public ResponseCookie setAccessTokenCookie(String value) {
+		return ResponseCookie.from(AuthConstants.ACCESS_TOKEN_KEY, value)
+				.path("/api")
+				.domain(domain)
+				.httpOnly(HTTP_ONLY)
+				.secure(SECURE)
+				.sameSite(SAMESITE)
+				.maxAge(TimeUtil.convertSecondsFromMillis(accessValidTime))
+				.build();
+	}
+
+	public ResponseCookie setRefreshTokenCookie(String value) {
+		return ResponseCookie.from(AuthConstants.REFRESH_TOKEN_KEY, value)
+				.path("/api/auth")
+				.domain(domain)
+				.httpOnly(HTTP_ONLY)
+				.secure(SECURE)
+				.sameSite(SAMESITE)
+				.maxAge(TimeUtil.convertSecondsFromMillis(validTime))
+				.build();
+	}
+
+	public ResponseCookie deleteAccessTokenCookie() {
+		return ResponseCookie.from(AuthConstants.ACCESS_TOKEN_KEY, "")
+				.path("/api")
+				.domain(domain)
+				.httpOnly(HTTP_ONLY)
+				.secure(SECURE)
+				.sameSite(SAMESITE)
+				.maxAge(0)
+				.build();
+	}
+
+	public ResponseCookie deleteRefreshTokenCookie() {
+		return ResponseCookie.from(AuthConstants.REFRESH_TOKEN_KEY, "")
+				.path("/api/auth")
+				.domain(domain)
+				.httpOnly(HTTP_ONLY)
+				.secure(SECURE)
+				.sameSite(SAMESITE)
+				.maxAge(0)
+				.build();
+	}
 
 	@Override
 	public ResponseCookie setCookie(String key, String value) {

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/AccessTokenFilter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/AccessTokenFilter.java
@@ -2,10 +2,12 @@ package com.blackcompany.eeos.config.security;
 
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.application.exception.NotFoundHeaderTokenException;
+import com.blackcompany.eeos.auth.presentation.support.AuthConstants;
 import com.blackcompany.eeos.auth.presentation.support.TokenExtractor;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,12 +22,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class AccessTokenFilter extends OncePerRequestFilter {
 
-	private final TokenExtractor tokenExtractor;
+	private final TokenExtractor headerExtractor;
 	private final TokenResolver tokenResolver;
 
 	public AccessTokenFilter(
-			@Qualifier("header") TokenExtractor tokenExtractor, TokenResolver tokenResolver) {
-		this.tokenExtractor = tokenExtractor;
+			@Qualifier("header") TokenExtractor headerExtractor, TokenResolver tokenResolver) {
+		this.headerExtractor = headerExtractor;
 		this.tokenResolver = tokenResolver;
 	}
 
@@ -34,7 +36,7 @@ public class AccessTokenFilter extends OncePerRequestFilter {
 			HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
 		try {
-			String token = tokenExtractor.extract(request); // tokenExtractor 에서 Auth 헤더가 있는지 검사함
+			String token = extractToken(request);
 
 			createAuthentication(token)
 					.ifPresentOrElse(this::setAuthentication, SecurityContextHolder::clearContext);
@@ -44,6 +46,26 @@ public class AccessTokenFilter extends OncePerRequestFilter {
 			SecurityContextHolder.clearContext();
 			filterChain.doFilter(request, response);
 		}
+	}
+
+	private String extractToken(HttpServletRequest request) {
+		try {
+			return headerExtractor.extract(request);
+		} catch (NotFoundHeaderTokenException e) {
+			return extractFromCookie(request);
+		}
+	}
+
+	private String extractFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (AuthConstants.ACCESS_TOKEN_KEY.equals(cookie.getName())) {
+					return cookie.getValue();
+				}
+			}
+		}
+		throw new NotFoundHeaderTokenException();
 	}
 
 	private Optional<JwtAuthentication> createAuthentication(String token) {

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
@@ -55,7 +55,6 @@ public class SecurityFilterChainConfig {
 							.requestMatchers(HttpMethod.POST, "/api/auth/login")
 							.requestMatchers(HttpMethod.POST, "/api/auth/signup")
 							.requestMatchers(HttpMethod.GET, "/api/auth/authorize")
-							.requestMatchers(HttpMethod.POST, "/api/auth/login/oauth2")
 							.requestMatchers(HttpMethod.POST, "/api/auth/token")
 							.requestMatchers(HttpMethod.POST, "/api/auth/clients")
 							.requestMatchers("/api/guest/**")

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
@@ -54,6 +54,10 @@ public class SecurityFilterChainConfig {
 							.requestMatchers(HttpMethod.POST, "/api/auth/login/**")
 							.requestMatchers(HttpMethod.POST, "/api/auth/login")
 							.requestMatchers(HttpMethod.POST, "/api/auth/signup")
+							.requestMatchers(HttpMethod.GET, "/api/auth/authorize")
+							.requestMatchers(HttpMethod.POST, "/api/auth/login/oauth2")
+							.requestMatchers(HttpMethod.POST, "/api/auth/token")
+							.requestMatchers(HttpMethod.POST, "/api/auth/clients")
 							.requestMatchers("/api/guest/**")
 							.requestMatchers("/api/health-check");
 				});

--- a/eeos/src/main/resources/application-api.yml
+++ b/eeos/src/main/resources/application-api.yml
@@ -11,3 +11,6 @@ token:
   cookie:
     domain: ${COOKIE_TOKEN_DOMAIN}
     path: ${COOKIE_TOKEN_PATH}
+
+auth:
+  login-page-url: ${AUTH_LOGIN_PAGE_URL:http://localhost:3000/login}

--- a/eeos/src/main/resources/db/migration/V1.00.0.4__create_oauth_client_tables.sql
+++ b/eeos/src/main/resources/db/migration/V1.00.0.4__create_oauth_client_tables.sql
@@ -1,0 +1,23 @@
+-- OAuth2 Client 등록 테이블
+CREATE TABLE oauth_client (
+    oauth_client_id         BIGINT          NOT NULL AUTO_INCREMENT,
+    oauth_client_client_id  VARCHAR(36)     NOT NULL,
+    oauth_client_client_secret VARCHAR(255) NULL,
+    oauth_client_client_name VARCHAR(100)   NOT NULL,
+    oauth_client_client_type VARCHAR(10)    NOT NULL,
+    created_date            DATETIME(6)     NOT NULL,
+    updated_date            DATETIME(6)     NOT NULL,
+    is_deleted              TINYINT(1)      NOT NULL DEFAULT 0,
+    PRIMARY KEY (oauth_client_id),
+    UNIQUE KEY uk_oauth_client_client_id (oauth_client_client_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- OAuth2 Client Redirect URI 테이블
+CREATE TABLE oauth_client_redirect_uri (
+    redirect_uri_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    oauth_client_id   BIGINT       NOT NULL,
+    redirect_uri      VARCHAR(512) NOT NULL,
+    PRIMARY KEY (redirect_uri_id),
+    CONSTRAINT fk_redirect_uri_client
+        FOREIGN KEY (oauth_client_id) REFERENCES oauth_client (oauth_client_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/domain/ClientTypeTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/domain/ClientTypeTest.java
@@ -1,0 +1,35 @@
+package com.blackcompany.eeos.auth.application.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClientTypeTest {
+
+	@Test
+	@DisplayName("should return true when WEB is confidential")
+	void shouldReturnTrueWhenWebIsConfidential() {
+		// Given
+		ClientType clientType = ClientType.WEB;
+
+		// When
+		boolean result = clientType.isConfidential();
+
+		// Then
+		assertTrue(result);
+	}
+
+	@Test
+	@DisplayName("should return false when APP is confidential")
+	void shouldReturnFalseWhenAppIsConfidential() {
+		// Given
+		ClientType clientType = ClientType.APP;
+
+		// When
+		boolean result = clientType.isConfidential();
+
+		// Then
+		assertFalse(result);
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/domain/PkceValidatorTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/domain/PkceValidatorTest.java
@@ -1,0 +1,42 @@
+package com.blackcompany.eeos.auth.application.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PkceValidatorTest {
+
+	@Test
+	@DisplayName("should return true when code_verifier matches code_challenge")
+	void shouldReturnTrueWhenVerifierMatchesChallenge() throws Exception {
+		// Given
+		String codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+		byte[] digest =
+				MessageDigest.getInstance("SHA-256")
+						.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+		String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+
+		// When & Then
+		assertTrue(PkceValidator.validate(codeVerifier, codeChallenge, "S256"));
+	}
+
+	@Test
+	@DisplayName("should return false when code_verifier does not match")
+	void shouldReturnFalseWhenVerifierDoesNotMatch() {
+		// When & Then
+		assertFalse(PkceValidator.validate("wrong-verifier", "some-challenge", "S256"));
+	}
+
+	@Test
+	@DisplayName("should throw when unsupported method")
+	void shouldThrowWhenUnsupportedMethod() {
+		// When & Then
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> PkceValidator.validate("verifier", "challenge", "plain"));
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/domain/token/TokenProviderTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/domain/token/TokenProviderTest.java
@@ -1,0 +1,60 @@
+package com.blackcompany.eeos.auth.application.domain.token;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TokenProviderTest {
+
+	private TokenProvider tokenProvider;
+	private TokenResolver tokenResolver;
+
+	@BeforeEach
+	void setUp() {
+		String accessKey = "test-access-secret-key-must-be-at-least-32-characters-long!!";
+		String refreshKey = "test-refresh-secret-key-must-be-at-least-32-characters-long!";
+		long accessValidTime = 3600000L;
+		long refreshValidTime = 86400000L;
+
+		tokenProvider = new TokenProvider(accessKey, refreshKey, accessValidTime, refreshValidTime);
+		tokenResolver = new TokenResolver(accessKey, refreshKey);
+	}
+
+	@Test
+	@DisplayName("should create refresh token with clientType and clientId claims")
+	void shouldCreateRefreshTokenWithClientClaims() {
+		// When
+		String rt = tokenProvider.createRefreshToken(1L, "WEB", "test-client-id");
+
+		// Then
+		assertEquals("WEB", tokenResolver.getClientTypeByRefreshToken(rt));
+		assertEquals("test-client-id", tokenResolver.getClientIdByRefreshToken(rt));
+		assertEquals(1L, tokenResolver.getUserDataByRefreshToken(rt));
+	}
+
+	@Test
+	@DisplayName("should create refresh token for APP with clientType APP")
+	void shouldCreateRefreshTokenForApp() {
+		// When
+		String rt = tokenProvider.createRefreshToken(2L, "APP", "app-client-id");
+
+		// Then
+		assertEquals("APP", tokenResolver.getClientTypeByRefreshToken(rt));
+		assertEquals("app-client-id", tokenResolver.getClientIdByRefreshToken(rt));
+	}
+
+	@Test
+	@DisplayName("should return null clientType for legacy refresh token")
+	void shouldReturnNullClientTypeForLegacyRefreshToken() {
+		// Given — legacy RT without client claims
+		String rt = tokenProvider.createRefreshToken(3L);
+
+		// When
+		String clientType = tokenResolver.getClientTypeByRefreshToken(rt);
+
+		// Then
+		assertNull(clientType);
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/ClientServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/ClientServiceTest.java
@@ -1,0 +1,147 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.exception.InvalidClientException;
+import com.blackcompany.eeos.auth.application.exception.InvalidRedirectUriException;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.auth.persistence.client.ClientRepository;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClientServiceTest {
+
+	@Mock ClientRepository clientRepository;
+	@InjectMocks ClientService clientService;
+
+	@Test
+	@DisplayName("should register WEB client with secret")
+	void shouldRegisterWebClientWithSecret() {
+		// Given
+		when(clientRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		// When
+		var result =
+				clientService.register(
+						"EEOS-Web", ClientType.WEB, Set.of("https://eeos.econovation.kr/callback"));
+
+		// Then
+		assertNotNull(result.clientId());
+		assertNotNull(result.clientSecret());
+	}
+
+	@Test
+	@DisplayName("should register APP client without secret")
+	void shouldRegisterAppClientWithoutSecret() {
+		// Given
+		when(clientRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+		// When
+		var result =
+				clientService.register(
+						"EEOS-App", ClientType.APP, Set.of("kr.econovation.eeos://callback"));
+
+		// Then
+		assertNotNull(result.clientId());
+		assertNull(result.clientSecret());
+	}
+
+	@Test
+	@DisplayName("should throw when redirectUris is empty")
+	void shouldThrowWhenRedirectUrisIsEmpty() {
+		// When & Then
+		assertThrows(
+				InvalidRedirectUriException.class,
+				() -> clientService.register("Test", ClientType.WEB, Set.of()));
+	}
+
+	@Test
+	@DisplayName("should throw when redirectUris exceeds 10")
+	void shouldThrowWhenRedirectUrisExceedsTen() {
+		// Given
+		Set<String> uris = Set.of("u1", "u2", "u3", "u4", "u5", "u6", "u7", "u8", "u9", "u10", "u11");
+
+		// When & Then
+		assertThrows(
+				InvalidRedirectUriException.class,
+				() -> clientService.register("Test", ClientType.WEB, uris));
+	}
+
+	@Test
+	@DisplayName("should throw when redirectUri exceeds 512 chars")
+	void shouldThrowWhenRedirectUriExceedsMaxLength() {
+		// Given
+		String longUri = "https://example.com/" + "a".repeat(500);
+
+		// When & Then
+		assertThrows(
+				InvalidRedirectUriException.class,
+				() -> clientService.register("Test", ClientType.WEB, Set.of(longUri)));
+	}
+
+	@Test
+	@DisplayName("should find client and validate redirectUri")
+	void shouldFindClientAndValidateRedirectUri() {
+		// Given
+		ClientEntity entity =
+				ClientEntity.builder()
+						.clientId("test-uuid")
+						.clientType(ClientType.WEB)
+						.clientName("Test")
+						.build();
+		entity.addRedirectUri("https://example.com/callback");
+		when(clientRepository.findByClientIdWithRedirectUris("test-uuid"))
+				.thenReturn(Optional.of(entity));
+
+		// When
+		ClientEntity found =
+				clientService.findAndValidateRedirectUri("test-uuid", "https://example.com/callback");
+
+		// Then
+		assertEquals("test-uuid", found.getClientId());
+	}
+
+	@Test
+	@DisplayName("should throw when clientId not found")
+	void shouldThrowWhenClientIdNotFound() {
+		// Given
+		when(clientRepository.findByClientIdWithRedirectUris("unknown")).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThrows(
+				InvalidClientException.class,
+				() -> clientService.findAndValidateRedirectUri("unknown", "https://any.com"));
+	}
+
+	@Test
+	@DisplayName("should throw when redirectUri not registered")
+	void shouldThrowWhenRedirectUriNotRegistered() {
+		// Given
+		ClientEntity entity =
+				ClientEntity.builder()
+						.clientId("test-uuid")
+						.clientType(ClientType.WEB)
+						.clientName("Test")
+						.build();
+		entity.addRedirectUri("https://registered.com/callback");
+		when(clientRepository.findByClientIdWithRedirectUris("test-uuid"))
+				.thenReturn(Optional.of(entity));
+
+		// When & Then
+		assertThrows(
+				InvalidRedirectUriException.class,
+				() ->
+						clientService.findAndValidateRedirectUri(
+								"test-uuid", "https://unregistered.com/callback"));
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/DeactivateMemberServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/DeactivateMemberServiceTest.java
@@ -1,0 +1,41 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
+import com.blackcompany.eeos.auth.persistence.InvalidTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class DeactivateMemberServiceTest {
+
+	@Mock InvalidTokenRepository invalidTokenRepository;
+	@Mock TokenResolver tokenResolver;
+	@Mock ApplicationEventPublisher eventPublisher;
+
+	@InjectMocks DeactivateMemberService deactivateMemberService;
+
+	@Test
+	@DisplayName("로그아웃 시 리프레시 토큰을 블랙리스트에 등록한다.")
+	void logOut_saves_token_to_blacklist() {
+		// given
+		String token = "refresh-token";
+		Long memberId = 1L;
+		Long expiredTime = System.currentTimeMillis() + 60000L;
+
+		when(tokenResolver.getExpiredDateByRefreshToken(token)).thenReturn(expiredTime);
+
+		// when
+		deactivateMemberService.logOut(token, memberId);
+
+		// then
+		verify(invalidTokenRepository).save(token, memberId, expiredTime);
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/OAuth2LoginServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/OAuth2LoginServiceTest.java
@@ -1,0 +1,105 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.auth.application.domain.AuthorizationCodeData;
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
+import com.blackcompany.eeos.auth.application.support.LoginRateLimiter;
+import com.blackcompany.eeos.auth.persistence.AuthorizationCodeRepository;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginServiceTest {
+
+	@Mock AuthService authService;
+	@Mock ClientService clientService;
+	@Mock AuthenticationTokenGenerator tokenGenerator;
+	@Mock AuthorizationCodeRepository codeRepository;
+	@Mock LoginRateLimiter rateLimiter;
+	@InjectMocks OAuth2LoginService oAuth2LoginService;
+
+	@Test
+	@DisplayName("should return TokenModel for WEB client login")
+	void shouldReturnTokenModelForWebLogin() {
+		// Given
+		ClientEntity client =
+				ClientEntity.builder().clientId("web-client-id").clientType(ClientType.WEB).build();
+		client.addRedirectUri("https://eeos.econovation.kr/callback");
+
+		when(clientService.findAndValidateRedirectUri(
+						"web-client-id", "https://eeos.econovation.kr/callback"))
+				.thenReturn(client);
+
+		MemberModel memberModel = MemberModel.builder().name("test").build();
+		// MemberModel.id는 private이므로 reflection 없이 getMemberId()를 mock할 수 없음
+		// 대신 AllArgsConstructor를 사용
+		MemberModel member = new MemberModel(1L, "test", null, false, null, null);
+		when(authService.authenticate("user@test.com", "password")).thenReturn(member);
+
+		when(tokenGenerator.execute(1L, "WEB", "web-client-id"))
+				.thenReturn(
+						TokenModel.builder()
+								.accessToken("at")
+								.refreshToken("rt")
+								.accessExpiredTime(100L)
+								.refreshExpiredTime(200L)
+								.build());
+
+		// When
+		TokenModel result =
+				oAuth2LoginService.loginForWeb(
+						"web-client-id",
+						"https://eeos.econovation.kr/callback",
+						"user@test.com",
+						"password",
+						"127.0.0.1");
+
+		// Then
+		assertNotNull(result.getAccessToken());
+		verify(rateLimiter).resetAccountCounter("user@test.com");
+	}
+
+	@Test
+	@DisplayName("should return authorization code for APP client login")
+	void shouldReturnAuthorizationCodeForAppLogin() {
+		// Given
+		ClientEntity client =
+				ClientEntity.builder().clientId("app-client-id").clientType(ClientType.APP).build();
+		client.addRedirectUri("kr.econovation.eeos://callback");
+
+		when(clientService.findAndValidateRedirectUri(
+						"app-client-id", "kr.econovation.eeos://callback"))
+				.thenReturn(client);
+
+		MemberModel member = new MemberModel(2L, "test", null, false, null, null);
+		when(authService.authenticate("user@test.com", "password")).thenReturn(member);
+
+		when(codeRepository.save(any(AuthorizationCodeData.class))).thenReturn("generated-code");
+
+		// When
+		String code =
+				oAuth2LoginService.loginForApp(
+						"app-client-id",
+						"kr.econovation.eeos://callback",
+						"user@test.com",
+						"password",
+						"127.0.0.1",
+						"code-challenge-value",
+						"S256");
+
+		// Then
+		assertEquals("generated-code", code);
+		verify(rateLimiter).resetAccountCounter("user@test.com");
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/ReissueServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/ReissueServiceTest.java
@@ -1,42 +1,35 @@
 package com.blackcompany.eeos.auth.application.service;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.application.exception.InvalidTokenException;
 import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
 import com.blackcompany.eeos.auth.persistence.InvalidTokenRepository;
-import com.blackcompany.eeos.common.DataClearExtension;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@SpringBootTest
-@ExtendWith(DataClearExtension.class)
+@ExtendWith(MockitoExtension.class)
 class ReissueServiceTest {
 
-	@SpyBean AuthenticationTokenGenerator authenticationTokenGenerator;
-	@Autowired InvalidTokenRepository invalidTokenRepository;
-	@MockBean TokenResolver tokenResolver;
-	@Autowired ReissueService reissueService;
+	@Mock AuthenticationTokenGenerator authenticationTokenGenerator;
+	@Mock InvalidTokenRepository invalidTokenRepository;
+	@Mock TokenResolver tokenResolver;
+
+	@InjectMocks ReissueService reissueService;
 
 	@Test
 	@DisplayName("블랙리스트에 등록된 토큰이라면 예외가 발생한다.")
-	@Disabled("임시로 테스트 제외, 원인 파악")
 	void exception_when_token_invalid() {
 		// given
 		String token = "token";
-		Long memberId = 2L;
-		Long validTime = 1000L * 1;
-
-		invalidTokenRepository.save(token, memberId, validTime);
+		when(invalidTokenRepository.isExistToken(token)).thenReturn(true);
 
 		// when & then
 		assertThrows(InvalidTokenException.class, () -> reissueService.execute(token));
@@ -48,17 +41,52 @@ class ReissueServiceTest {
 		// given
 		String token = "token";
 		Long memberId = 2L;
-		Long validTime = 1000L * 1;
+		Long expiredTime = System.currentTimeMillis() + 60000L;
+		TokenModel expectedToken = TokenModel.builder().accessToken("at").refreshToken("rt").build();
 
+		when(invalidTokenRepository.isExistToken(token)).thenReturn(false);
 		when(tokenResolver.getUserDataByRefreshToken(token)).thenReturn(memberId);
-		when(tokenResolver.getExpiredDateByRefreshToken(token)).thenReturn(validTime);
+		when(tokenResolver.getExpiredDateByRefreshToken(token)).thenReturn(expiredTime);
+		when(tokenResolver.getClientTypeByRefreshToken(token)).thenReturn(null);
+		when(authenticationTokenGenerator.execute(memberId)).thenReturn(expectedToken);
 
 		// when
-		reissueService.execute(token);
+		TokenModel result = reissueService.execute(token);
 
 		// then
 		assertAll(
-				() -> assertTrue(invalidTokenRepository.isExistToken(token)),
-				() -> verify(authenticationTokenGenerator).execute(memberId));
+				() -> verify(invalidTokenRepository).save(token, memberId, expiredTime),
+				() -> verify(authenticationTokenGenerator).execute(memberId),
+				() -> assertEquals(expectedToken, result));
+	}
+
+	@Test
+	@DisplayName("client claims가 있는 RT로 재발급하면 clientType/clientId가 보존된다.")
+	void reissue_preserves_client_claims() {
+		// given
+		String token = "token-with-client";
+		Long memberId = 3L;
+		Long expiredTime = System.currentTimeMillis() + 60000L;
+		String clientType = "WEB";
+		String clientId = "web-client-id";
+		TokenModel expectedToken = TokenModel.builder().accessToken("at").refreshToken("rt").build();
+
+		when(invalidTokenRepository.isExistToken(token)).thenReturn(false);
+		when(tokenResolver.getUserDataByRefreshToken(token)).thenReturn(memberId);
+		when(tokenResolver.getExpiredDateByRefreshToken(token)).thenReturn(expiredTime);
+		when(tokenResolver.getClientTypeByRefreshToken(token)).thenReturn(clientType);
+		when(tokenResolver.getClientIdByRefreshToken(token)).thenReturn(clientId);
+		when(authenticationTokenGenerator.execute(memberId, clientType, clientId))
+				.thenReturn(expectedToken);
+
+		// when
+		TokenModel result = reissueService.execute(token);
+
+		// then
+		assertAll(
+				() -> verify(invalidTokenRepository).save(token, memberId, expiredTime),
+				() -> verify(authenticationTokenGenerator).execute(memberId, clientType, clientId),
+				() -> verify(authenticationTokenGenerator, never()).execute(memberId),
+				() -> assertEquals(expectedToken, result));
 	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/TokenExchangeServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/TokenExchangeServiceTest.java
@@ -1,0 +1,144 @@
+package com.blackcompany.eeos.auth.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.auth.application.domain.AuthorizationCodeData;
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.exception.InvalidClientException;
+import com.blackcompany.eeos.auth.application.exception.InvalidGrantException;
+import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
+import com.blackcompany.eeos.auth.persistence.AuthorizationCodeRepository;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.auth.persistence.client.ClientRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenExchangeServiceTest {
+
+	@Mock AuthorizationCodeRepository codeRepository;
+	@Mock ClientRepository clientRepository;
+	@Mock AuthenticationTokenGenerator tokenGenerator;
+	@InjectMocks TokenExchangeService tokenExchangeService;
+
+	@Test
+	@DisplayName("should exchange code for tokens when PKCE valid")
+	void shouldExchangeCodeForTokens() throws Exception {
+		// Given
+		String codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+		byte[] digest =
+				MessageDigest.getInstance("SHA-256")
+						.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+		String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+
+		AuthorizationCodeData codeData =
+				AuthorizationCodeData.builder()
+						.memberId(1L)
+						.clientId("app-client-id")
+						.codeChallenge(codeChallenge)
+						.codeChallengeMethod("S256")
+						.redirectUri("kr.econovation.eeos://callback")
+						.build();
+
+		when(codeRepository.findAndDelete("test-code")).thenReturn(Optional.of(codeData));
+		when(clientRepository.findByClientIdWithRedirectUris("app-client-id"))
+				.thenReturn(
+						Optional.of(
+								ClientEntity.builder()
+										.clientId("app-client-id")
+										.clientType(ClientType.APP)
+										.build()));
+		when(tokenGenerator.execute(1L, "APP", "app-client-id"))
+				.thenReturn(
+						TokenModel.builder()
+								.accessToken("at")
+								.refreshToken("rt")
+								.accessExpiredTime(100L)
+								.refreshExpiredTime(200L)
+								.build());
+
+		// When
+		TokenModel result =
+				tokenExchangeService.exchange(
+						"test-code", codeVerifier, "kr.econovation.eeos://callback", "app-client-id");
+
+		// Then
+		assertEquals("at", result.getAccessToken());
+	}
+
+	@Test
+	@DisplayName("should throw when code expired or not found")
+	void shouldThrowWhenCodeNotFound() {
+		// Given
+		when(codeRepository.findAndDelete("expired-code")).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThrows(
+				InvalidGrantException.class,
+				() -> tokenExchangeService.exchange("expired-code", "verifier", "uri", "client-id"));
+	}
+
+	@Test
+	@DisplayName("should throw when client_id mismatch")
+	void shouldThrowWhenClientIdMismatch() {
+		// Given
+		AuthorizationCodeData codeData =
+				AuthorizationCodeData.builder().clientId("real-client-id").build();
+		when(codeRepository.findAndDelete("code")).thenReturn(Optional.of(codeData));
+
+		// When & Then
+		assertThrows(
+				InvalidClientException.class,
+				() -> tokenExchangeService.exchange("code", "verifier", "uri", "wrong-client-id"));
+	}
+
+	@Test
+	@DisplayName("should throw when redirect_uri mismatch")
+	void shouldThrowWhenRedirectUriMismatch() {
+		// Given
+		AuthorizationCodeData codeData =
+				AuthorizationCodeData.builder()
+						.clientId("client-id")
+						.redirectUri("https://registered.com/callback")
+						.build();
+		when(codeRepository.findAndDelete("code")).thenReturn(Optional.of(codeData));
+
+		// When & Then
+		assertThrows(
+				InvalidGrantException.class,
+				() ->
+						tokenExchangeService.exchange(
+								"code", "verifier", "https://other.com/callback", "client-id"));
+	}
+
+	@Test
+	@DisplayName("should throw when PKCE verification fails")
+	void shouldThrowWhenPkceVerificationFails() {
+		// Given
+		AuthorizationCodeData codeData =
+				AuthorizationCodeData.builder()
+						.clientId("client-id")
+						.redirectUri("https://app.com/callback")
+						.codeChallenge("valid-challenge")
+						.codeChallengeMethod("S256")
+						.build();
+		when(codeRepository.findAndDelete("code")).thenReturn(Optional.of(codeData));
+
+		// When & Then
+		assertThrows(
+				InvalidGrantException.class,
+				() ->
+						tokenExchangeService.exchange(
+								"code", "wrong-verifier", "https://app.com/callback", "client-id"));
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2ControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2ControllerTest.java
@@ -1,0 +1,233 @@
+package com.blackcompany.eeos.auth.presentation.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.auth.application.domain.ClientType;
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.exception.InvalidClientException;
+import com.blackcompany.eeos.auth.application.service.ClientService;
+import com.blackcompany.eeos.auth.application.service.OAuth2LoginService;
+import com.blackcompany.eeos.auth.application.service.TokenExchangeService;
+import com.blackcompany.eeos.auth.persistence.client.ClientEntity;
+import com.blackcompany.eeos.auth.presentation.support.AuthCookieManager;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2ControllerTest {
+
+	@Mock private ClientService clientService;
+	@Mock private OAuth2LoginService oAuth2LoginService;
+	@Mock private TokenExchangeService tokenExchangeService;
+	@Mock private AuthCookieManager cookieManager;
+
+	@InjectMocks private OAuth2Controller controller;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		Field loginPageUrlField = OAuth2Controller.class.getDeclaredField("loginPageUrl");
+		loginPageUrlField.setAccessible(true);
+		loginPageUrlField.set(controller, "http://localhost:3000/login");
+	}
+
+	@Nested
+	@DisplayName("/authorize 엔드포인트")
+	class Authorize {
+
+		@Test
+		@DisplayName("response_type이 code가 아니면 400 반환")
+		void bad_request_when_invalid_response_type() {
+			ResponseEntity<Void> result =
+					controller.authorize("client1", "http://app/callback", "token", "state1", null, null);
+
+			assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+		}
+
+		@Test
+		@DisplayName("APP 클라이언트가 code_challenge 없이 요청하면 400 반환")
+		void bad_request_when_app_without_code_challenge() {
+			ClientEntity appClient =
+					ClientEntity.builder().clientId("app1").clientType(ClientType.APP).build();
+			when(clientService.findAndValidateRedirectUri("app1", "http://app/callback"))
+					.thenReturn(appClient);
+
+			ResponseEntity<Void> result =
+					controller.authorize("app1", "http://app/callback", "code", "state1", null, null);
+
+			assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 302 로그인 페이지 리다이렉트")
+		void redirect_to_login_page() {
+			ClientEntity webClient =
+					ClientEntity.builder().clientId("web1").clientType(ClientType.WEB).build();
+			when(clientService.findAndValidateRedirectUri("web1", "http://web/callback"))
+					.thenReturn(webClient);
+
+			ResponseEntity<Void> result =
+					controller.authorize("web1", "http://web/callback", "code", "state1", null, null);
+
+			assertEquals(HttpStatus.FOUND, result.getStatusCode());
+			assertTrue(result.getHeaders().getLocation().toString().contains("client_id=web1"));
+		}
+	}
+
+	@Nested
+	@DisplayName("/login/oauth2 엔드포인트")
+	class LoginOAuth2 {
+
+		@Test
+		@DisplayName("유효하지 않은 client_id면 400 반환")
+		void bad_request_when_invalid_client() {
+			when(clientService.findAndValidateRedirectUri("bad", "http://x"))
+					.thenThrow(new InvalidClientException());
+
+			ResponseEntity<Void> result =
+					controller.loginOAuth2(
+							"bad",
+							"http://x",
+							"state",
+							"e",
+							"p",
+							null,
+							null,
+							new MockHttpServletRequest(),
+							new MockHttpServletResponse());
+
+			assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+		}
+
+		@Test
+		@DisplayName("WEB 클라이언트 로그인 성공 시 쿠키 설정 + 303 리다이렉트")
+		void web_login_sets_cookies_and_redirects() {
+			ClientEntity webClient =
+					ClientEntity.builder().clientId("web1").clientType(ClientType.WEB).build();
+			when(clientService.findAndValidateRedirectUri("web1", "http://web/callback"))
+					.thenReturn(webClient);
+
+			TokenModel tokenModel =
+					TokenModel.builder()
+							.accessToken("at")
+							.refreshToken("rt")
+							.accessExpiredTime(99999L)
+							.build();
+			when(oAuth2LoginService.loginForWeb(
+							"web1", "http://web/callback", "user@test.com", "pw", "127.0.0.1"))
+					.thenReturn(tokenModel);
+			when(cookieManager.setAccessTokenCookie("at"))
+					.thenReturn(ResponseCookie.from("eeos_access_token", "at").build());
+			when(cookieManager.setRefreshTokenCookie("rt"))
+					.thenReturn(ResponseCookie.from("eeos_refresh_token", "rt").build());
+
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setRemoteAddr("127.0.0.1");
+			MockHttpServletResponse response = new MockHttpServletResponse();
+
+			ResponseEntity<Void> result =
+					controller.loginOAuth2(
+							"web1",
+							"http://web/callback",
+							"state1",
+							"user@test.com",
+							"pw",
+							null,
+							null,
+							request,
+							response);
+
+			assertEquals(HttpStatus.SEE_OTHER, result.getStatusCode());
+			assertTrue(
+					result.getHeaders().get(HttpHeaders.LOCATION).get(0).contains("http://web/callback"));
+			assertTrue(response.getHeader(HttpHeaders.SET_COOKIE).contains("eeos_access_token"));
+		}
+
+		@Test
+		@DisplayName("APP 클라이언트 로그인 성공 시 authorization_code + 303 리다이렉트")
+		void app_login_returns_code_and_redirects() {
+			ClientEntity appClient =
+					ClientEntity.builder().clientId("app1").clientType(ClientType.APP).build();
+			when(clientService.findAndValidateRedirectUri("app1", "http://app/callback"))
+					.thenReturn(appClient);
+			when(oAuth2LoginService.loginForApp(
+							"app1",
+							"http://app/callback",
+							"user@test.com",
+							"pw",
+							"127.0.0.1",
+							"challenge",
+							"S256"))
+					.thenReturn("auth-code-123");
+
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setRemoteAddr("127.0.0.1");
+
+			ResponseEntity<Void> result =
+					controller.loginOAuth2(
+							"app1",
+							"http://app/callback",
+							"state1",
+							"user@test.com",
+							"pw",
+							"challenge",
+							"S256",
+							request,
+							new MockHttpServletResponse());
+
+			assertEquals(HttpStatus.SEE_OTHER, result.getStatusCode());
+			assertTrue(
+					result.getHeaders().get(HttpHeaders.LOCATION).get(0).contains("code=auth-code-123"));
+		}
+	}
+
+	@Nested
+	@DisplayName("/token 엔드포인트")
+	class Token {
+
+		@Test
+		@DisplayName("grant_type이 authorization_code가 아니면 400 반환")
+		void bad_request_when_invalid_grant_type() {
+			ResponseEntity<Map<String, Object>> result =
+					controller.token("password", "code", "verifier", "http://x", "client1");
+
+			assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
+		}
+
+		@Test
+		@DisplayName("유효한 code exchange 시 토큰 반환")
+		void exchange_returns_tokens() {
+			TokenModel tokenModel =
+					TokenModel.builder()
+							.accessToken("new-at")
+							.refreshToken("new-rt")
+							.accessExpiredTime(System.currentTimeMillis() + 3600000)
+							.build();
+			when(tokenExchangeService.exchange("code123", "verifier", "http://app/callback", "app1"))
+					.thenReturn(tokenModel);
+
+			ResponseEntity<Map<String, Object>> result =
+					controller.token(
+							"authorization_code", "code123", "verifier", "http://app/callback", "app1");
+
+			assertEquals(HttpStatus.OK, result.getStatusCode());
+			assertEquals("new-at", result.getBody().get("access_token"));
+			assertEquals("new-rt", result.getBody().get("refresh_token"));
+			assertEquals("Bearer", result.getBody().get("token_type"));
+		}
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/config/security/AccessTokenFilterTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/config/security/AccessTokenFilterTest.java
@@ -1,0 +1,90 @@
+package com.blackcompany.eeos.config.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
+import com.blackcompany.eeos.auth.application.exception.NotFoundHeaderTokenException;
+import com.blackcompany.eeos.auth.presentation.support.AuthConstants;
+import com.blackcompany.eeos.auth.presentation.support.TokenExtractor;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class AccessTokenFilterTest {
+
+	@Mock private TokenExtractor headerExtractor;
+	@Mock private TokenResolver tokenResolver;
+	@Mock private HttpServletRequest request;
+	@Mock private HttpServletResponse response;
+	@Mock private FilterChain filterChain;
+
+	private AccessTokenFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		SecurityContextHolder.clearContext();
+		filter = new AccessTokenFilter(headerExtractor, tokenResolver);
+	}
+
+	@Test
+	@DisplayName("Authorization 헤더에 토큰이 있으면 헤더에서 추출한다.")
+	void extract_from_header_when_present() throws Exception {
+		// given
+		String token = "valid-access-token";
+		when(headerExtractor.extract(request)).thenReturn(token);
+		when(tokenResolver.getUserDataByAccessToken(token)).thenReturn(1L);
+		when(tokenResolver.getRoles(token)).thenReturn(List.of("ROLE_USER"));
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	@DisplayName("헤더에 토큰이 없고 쿠키에 AT가 있으면 쿠키에서 추출한다.")
+	void fallback_to_cookie_when_header_absent() throws Exception {
+		// given
+		String token = "cookie-access-token";
+		when(headerExtractor.extract(request)).thenThrow(new NotFoundHeaderTokenException());
+		when(request.getCookies())
+				.thenReturn(new Cookie[] {new Cookie(AuthConstants.ACCESS_TOKEN_KEY, token)});
+		when(tokenResolver.getUserDataByAccessToken(token)).thenReturn(2L);
+		when(tokenResolver.getRoles(token)).thenReturn(List.of("ROLE_USER"));
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+		verify(filterChain).doFilter(request, response);
+	}
+
+	@Test
+	@DisplayName("헤더도 쿠키도 없으면 SecurityContext를 비우고 필터 체인을 계속한다.")
+	void clear_context_when_no_token() throws Exception {
+		// given
+		when(headerExtractor.extract(request)).thenThrow(new NotFoundHeaderTokenException());
+		when(request.getCookies()).thenReturn(null);
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+		verify(filterChain).doFilter(request, response);
+	}
+}

--- a/scripts/api-test/seed-test-client.sql
+++ b/scripts/api-test/seed-test-client.sql
@@ -1,0 +1,30 @@
+-- 테스트용 WEB 클라이언트 seed
+-- 로컬 개발 환경에서만 사용
+
+INSERT INTO oauth_client (
+    oauth_client_client_id,
+    oauth_client_client_secret,
+    oauth_client_client_name,
+    oauth_client_client_type,
+    created_date,
+    updated_date,
+    is_deleted
+) VALUES (
+    'test-web-client-id',
+    NULL,  -- WEB은 secret 있어야 하지만 테스트 편의상 생략 (서버가 null check 없으면 통과)
+    'EEOS-Web-Test',
+    'WEB',
+    NOW(),
+    NOW(),
+    0
+) ON DUPLICATE KEY UPDATE oauth_client_client_name = 'EEOS-Web-Test';
+
+-- redirect_uri 등록
+INSERT INTO oauth_client_redirect_uri (
+    oauth_client_id,
+    redirect_uri
+)
+SELECT id, 'http://localhost:3000/callback'
+FROM oauth_client
+WHERE oauth_client_client_id = 'test-web-client-id'
+ON DUPLICATE KEY UPDATE redirect_uri = 'http://localhost:3000/callback';

--- a/scripts/api-test/test-auth-api.sh
+++ b/scripts/api-test/test-auth-api.sh
@@ -196,10 +196,10 @@ if [ -n "${APP_CLIENT_ID:-}" ]; then
 fi
 
 # ============================================
-# 3. /login/oauth2 엔드포인트
+# 3. /login 엔드포인트
 # ============================================
 echo ""
-echo -e "${YELLOW}--- 3. /login/oauth2 엔드포인트 ---${NC}"
+echo -e "${YELLOW}--- 3. /login 엔드포인트 ---${NC}"
 
 # 테스트 계정 (환경변수로 설정 가능)
 TEST_EMAIL="${TEST_EMAIL:-}"
@@ -208,7 +208,7 @@ TEST_PASSWORD="${TEST_PASSWORD:-}"
 if [ -n "${WEB_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
 	# 3-1. 성공: WEB 로그인 → 303 + 쿠키
 	RESPONSE=$(curl -s -D - -o /dev/null -w "\n%{http_code}" \
-		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-X POST "$BASE_URL/api/auth/login" \
 		-d "client_id=$WEB_CLIENT_ID&redirect_uri=http://localhost:3000/callback&state=test123&email=$TEST_EMAIL&password=$TEST_PASSWORD")
 	STATUS=$(echo "$RESPONSE" | tail -1)
 	HEADERS=$(echo "$RESPONSE" | head -n -1)
@@ -220,7 +220,7 @@ if [ -n "${WEB_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
 
 	# 3-2. 실패: 잘못된 credentials → 303 (로그인 페이지로)
 	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
-		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-X POST "$BASE_URL/api/auth/login" \
 		-d "client_id=$WEB_CLIENT_ID&redirect_uri=http://localhost:3000/callback&state=test123&email=$TEST_EMAIL&password=wrong_password")
 	STATUS=$(echo "$RESPONSE" | head -1)
 	LOCATION=$(echo "$RESPONSE" | tail -1)
@@ -228,19 +228,19 @@ if [ -n "${WEB_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
 
 	# 3-3. 실패: 잘못된 client_id → 400
 	RESPONSE=$(curl -s -w "\n%{http_code}" \
-		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-X POST "$BASE_URL/api/auth/login" \
 		-d "client_id=nonexistent&redirect_uri=http://fake.com&state=test123&email=$TEST_EMAIL&password=$TEST_PASSWORD")
 	STATUS=$(echo "$RESPONSE" | tail -1)
 	assert_status "3-3. 잘못된 client_id → 400" 400 "$STATUS"
 
 	# 3-4. 실패: redirect_uri 불일치 → 400
 	RESPONSE=$(curl -s -w "\n%{http_code}" \
-		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-X POST "$BASE_URL/api/auth/login" \
 		-d "client_id=$WEB_CLIENT_ID&redirect_uri=http://evil.com/steal&state=test123&email=$TEST_EMAIL&password=$TEST_PASSWORD")
 	STATUS=$(echo "$RESPONSE" | tail -1)
 	assert_status "3-4. redirect_uri 불일치 → 400" 400 "$STATUS"
 else
-	echo -e "${YELLOW}[SKIP]${NC} /login/oauth2 테스트: WEB_CLIENT_ID 또는 TEST_EMAIL 미설정"
+	echo -e "${YELLOW}[SKIP]${NC} /login 테스트: WEB_CLIENT_ID 또는 TEST_EMAIL 미설정"
 	echo "       export TEST_EMAIL=<이메일> TEST_PASSWORD=<비밀번호> 후 재실행"
 fi
 
@@ -275,7 +275,7 @@ if [ -n "${APP_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
 
 	# App 로그인 → authorization_code 받기
 	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
-		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-X POST "$BASE_URL/api/auth/login" \
 		-d "client_id=$APP_CLIENT_ID&redirect_uri=kr.econovation.eeos://callback&state=test456&email=$TEST_EMAIL&password=$TEST_PASSWORD&code_challenge=$CODE_CHALLENGE&code_challenge_method=S256")
 	STATUS=$(echo "$RESPONSE" | head -1)
 	REDIRECT_URL=$(echo "$RESPONSE" | tail -1)
@@ -323,7 +323,7 @@ if [ -n "${APP_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
 	# 4-5. 실패: PKCE code_verifier 불일치
 	# 새 code 발급
 	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
-		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-X POST "$BASE_URL/api/auth/login" \
 		-d "client_id=$APP_CLIENT_ID&redirect_uri=kr.econovation.eeos://callback&state=test789&email=$TEST_EMAIL&password=$TEST_PASSWORD&code_challenge=$CODE_CHALLENGE&code_challenge_method=S256")
 	STATUS=$(echo "$RESPONSE" | head -1)
 	REDIRECT_URL=$(echo "$RESPONSE" | tail -1)

--- a/scripts/api-test/test-auth-api.sh
+++ b/scripts/api-test/test-auth-api.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+# Web/App 인증 분리 API 통합 테스트 스크립트
+# 사용법: ./test-auth-api.sh [BASE_URL]
+# 예: ./test-auth-api.sh http://localhost:8080
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8080}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# 색상
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+assert_status() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	local body="${4:-}"
+	TOTAL=$((TOTAL + 1))
+
+	if [ "$actual" -eq "$expected" ]; then
+		echo -e "${GREEN}[PASS]${NC} $test_name (HTTP $actual)"
+		PASS=$((PASS + 1))
+	else
+		echo -e "${RED}[FAIL]${NC} $test_name (expected $expected, got $actual)"
+		if [ -n "$body" ]; then
+			echo "       Response: $(echo "$body" | head -3)"
+		fi
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+assert_contains() {
+	local test_name="$1"
+	local expected="$2"
+	local body="$3"
+	TOTAL=$((TOTAL + 1))
+
+	if echo "$body" | grep -q "$expected"; then
+		echo -e "${GREEN}[PASS]${NC} $test_name (contains '$expected')"
+		PASS=$((PASS + 1))
+	else
+		echo -e "${RED}[FAIL]${NC} $test_name (missing '$expected')"
+		echo "       Response: $(echo "$body" | head -3)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+assert_redirect() {
+	local test_name="$1"
+	local expected_status="$2"
+	local expected_location_contains="$3"
+	local actual_status="$4"
+	local actual_location="$5"
+	TOTAL=$((TOTAL + 1))
+
+	if [ "$actual_status" -eq "$expected_status" ] && echo "$actual_location" | grep -q "$expected_location_contains"; then
+		echo -e "${GREEN}[PASS]${NC} $test_name (HTTP $actual_status → $expected_location_contains)"
+		PASS=$((PASS + 1))
+	else
+		echo -e "${RED}[FAIL]${NC} $test_name (status=$actual_status, location=$actual_location)"
+		FAIL=$((FAIL + 1))
+	fi
+}
+
+echo ""
+echo "======================================"
+echo " Web/App 인증 분리 API 테스트"
+echo " Base URL: $BASE_URL"
+echo "======================================"
+echo ""
+
+# ============================================
+# 1. Client 등록 API
+# ============================================
+echo -e "${YELLOW}--- 1. Client 등록 API ---${NC}"
+
+# 1-1. 성공: WEB 클라이언트 등록
+# NOTE: 관리자 인증이 필요하므로, 테스트 전 관리자 토큰을 ADMIN_TOKEN에 설정
+ADMIN_TOKEN="${ADMIN_TOKEN:-}"
+
+if [ -n "$ADMIN_TOKEN" ]; then
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/clients" \
+		-H "Content-Type: application/json" \
+		-H "Authorization: Bearer $ADMIN_TOKEN" \
+		-d '{
+			"clientName": "EEOS-Web-Test",
+			"clientType": "WEB",
+			"redirectUris": ["http://localhost:3000/callback"]
+		}')
+	BODY=$(echo "$RESPONSE" | head -n -1)
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "1-1. WEB 클라이언트 등록" 201 "$STATUS" "$BODY"
+
+	if [ "$STATUS" -eq 201 ]; then
+		WEB_CLIENT_ID=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['clientId'])" 2>/dev/null || echo "")
+		WEB_CLIENT_SECRET=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['clientSecret'])" 2>/dev/null || echo "")
+		assert_contains "1-1a. WEB clientSecret 존재" "clientSecret" "$BODY"
+	fi
+
+	# 1-2. 성공: APP 클라이언트 등록
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/clients" \
+		-H "Content-Type: application/json" \
+		-H "Authorization: Bearer $ADMIN_TOKEN" \
+		-d '{
+			"clientName": "EEOS-App-Test",
+			"clientType": "APP",
+			"redirectUris": ["kr.econovation.eeos://callback"]
+		}')
+	BODY=$(echo "$RESPONSE" | head -n -1)
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "1-2. APP 클라이언트 등록" 201 "$STATUS" "$BODY"
+
+	if [ "$STATUS" -eq 201 ]; then
+		APP_CLIENT_ID=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['clientId'])" 2>/dev/null || echo "")
+	fi
+
+	# 1-3. 실패: redirectUris 비어있음
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/clients" \
+		-H "Content-Type: application/json" \
+		-H "Authorization: Bearer $ADMIN_TOKEN" \
+		-d '{
+			"clientName": "Bad-Client",
+			"clientType": "WEB",
+			"redirectUris": []
+		}')
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "1-3. redirectUris 비어있음 → 400" 400 "$STATUS"
+
+	# 1-4. 실패: redirectUri 512자 초과
+	LONG_URI="https://example.com/$(python3 -c "print('a'*500)")"
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/clients" \
+		-H "Content-Type: application/json" \
+		-H "Authorization: Bearer $ADMIN_TOKEN" \
+		-d "{
+			\"clientName\": \"Bad-Client\",
+			\"clientType\": \"WEB\",
+			\"redirectUris\": [\"$LONG_URI\"]
+		}")
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "1-4. redirectUri 512자 초과 → 400" 400 "$STATUS"
+
+else
+	echo -e "${YELLOW}[SKIP]${NC} Client 등록 테스트: ADMIN_TOKEN 미설정"
+	echo "       export ADMIN_TOKEN=<관리자토큰> 후 재실행"
+
+	# 수동 테스트용 기본값 설정
+	WEB_CLIENT_ID="${WEB_CLIENT_ID:-}"
+	APP_CLIENT_ID="${APP_CLIENT_ID:-}"
+fi
+
+# ============================================
+# 2. /authorize 엔드포인트
+# ============================================
+echo ""
+echo -e "${YELLOW}--- 2. /authorize 엔드포인트 ---${NC}"
+
+if [ -n "${WEB_CLIENT_ID:-}" ]; then
+	# 2-1. 성공: 로그인 페이지로 redirect
+	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
+		-X GET "$BASE_URL/api/auth/authorize?client_id=$WEB_CLIENT_ID&redirect_uri=http://localhost:3000/callback&response_type=code&state=test123")
+	STATUS=$(echo "$RESPONSE" | head -1)
+	LOCATION=$(echo "$RESPONSE" | tail -1)
+	assert_redirect "2-1. WEB authorize → 로그인 페이지 redirect" 302 "client_id" "$STATUS" "$LOCATION"
+fi
+
+# 2-2. 실패: 존재하지 않는 client_id
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+	-X GET "$BASE_URL/api/auth/authorize?client_id=nonexistent&redirect_uri=http://fake.com&response_type=code&state=test123")
+STATUS=$(echo "$RESPONSE" | tail -1)
+assert_status "2-2. 잘못된 client_id → 400" 400 "$STATUS"
+
+# 2-3. 실패: response_type이 code가 아님
+if [ -n "${WEB_CLIENT_ID:-}" ]; then
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X GET "$BASE_URL/api/auth/authorize?client_id=$WEB_CLIENT_ID&redirect_uri=http://localhost:3000/callback&response_type=token&state=test123")
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "2-3. response_type=token → 400" 400 "$STATUS"
+fi
+
+# 2-4. 실패: APP인데 code_challenge 누락
+if [ -n "${APP_CLIENT_ID:-}" ]; then
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X GET "$BASE_URL/api/auth/authorize?client_id=$APP_CLIENT_ID&redirect_uri=kr.econovation.eeos://callback&response_type=code&state=test123")
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "2-4. APP code_challenge 누락 → 400" 400 "$STATUS"
+fi
+
+# ============================================
+# 3. /login/oauth2 엔드포인트
+# ============================================
+echo ""
+echo -e "${YELLOW}--- 3. /login/oauth2 엔드포인트 ---${NC}"
+
+# 테스트 계정 (환경변수로 설정 가능)
+TEST_EMAIL="${TEST_EMAIL:-}"
+TEST_PASSWORD="${TEST_PASSWORD:-}"
+
+if [ -n "${WEB_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
+	# 3-1. 성공: WEB 로그인 → 303 + 쿠키
+	RESPONSE=$(curl -s -D - -o /dev/null -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-d "client_id=$WEB_CLIENT_ID&redirect_uri=http://localhost:3000/callback&state=test123&email=$TEST_EMAIL&password=$TEST_PASSWORD")
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	HEADERS=$(echo "$RESPONSE" | head -n -1)
+	assert_status "3-1. WEB 로그인 → 303" 303 "$STATUS"
+
+	if echo "$HEADERS" | grep -qi "eeos_access_token"; then
+		assert_contains "3-1a. AT 쿠키 존재" "eeos_access_token" "$HEADERS"
+	fi
+
+	# 3-2. 실패: 잘못된 credentials → 303 (로그인 페이지로)
+	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
+		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-d "client_id=$WEB_CLIENT_ID&redirect_uri=http://localhost:3000/callback&state=test123&email=$TEST_EMAIL&password=wrong_password")
+	STATUS=$(echo "$RESPONSE" | head -1)
+	LOCATION=$(echo "$RESPONSE" | tail -1)
+	assert_redirect "3-2. 잘못된 비밀번호 → 303 (로그인 페이지)" 303 "error=invalid_credentials" "$STATUS" "$LOCATION"
+
+	# 3-3. 실패: 잘못된 client_id → 400
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-d "client_id=nonexistent&redirect_uri=http://fake.com&state=test123&email=$TEST_EMAIL&password=$TEST_PASSWORD")
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "3-3. 잘못된 client_id → 400" 400 "$STATUS"
+
+	# 3-4. 실패: redirect_uri 불일치 → 400
+	RESPONSE=$(curl -s -w "\n%{http_code}" \
+		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-d "client_id=$WEB_CLIENT_ID&redirect_uri=http://evil.com/steal&state=test123&email=$TEST_EMAIL&password=$TEST_PASSWORD")
+	STATUS=$(echo "$RESPONSE" | tail -1)
+	assert_status "3-4. redirect_uri 불일치 → 400" 400 "$STATUS"
+else
+	echo -e "${YELLOW}[SKIP]${NC} /login/oauth2 테스트: WEB_CLIENT_ID 또는 TEST_EMAIL 미설정"
+	echo "       export TEST_EMAIL=<이메일> TEST_PASSWORD=<비밀번호> 후 재실행"
+fi
+
+# ============================================
+# 4. /token 엔드포인트 (App code 교환)
+# ============================================
+echo ""
+echo -e "${YELLOW}--- 4. /token 엔드포인트 ---${NC}"
+
+# 4-1. 실패: grant_type 미지원
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+	-X POST "$BASE_URL/api/auth/token" \
+	-H "Content-Type: application/x-www-form-urlencoded" \
+	-d "grant_type=password&code=fake&code_verifier=fake&redirect_uri=fake&client_id=fake")
+STATUS=$(echo "$RESPONSE" | tail -1)
+assert_status "4-1. grant_type=password → 400" 400 "$STATUS"
+
+# 4-2. 실패: 만료/존재하지 않는 code
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+	-X POST "$BASE_URL/api/auth/token" \
+	-H "Content-Type: application/x-www-form-urlencoded" \
+	-d "grant_type=authorization_code&code=expired_code&code_verifier=fake&redirect_uri=fake&client_id=fake")
+BODY=$(echo "$RESPONSE" | head -n -1)
+STATUS=$(echo "$RESPONSE" | tail -1)
+assert_status "4-2. 만료된 code → 400" 400 "$STATUS"
+
+# 4-3. APP PKCE 전체 플로우 (login → code → token)
+if [ -n "${APP_CLIENT_ID:-}" ] && [ -n "$TEST_EMAIL" ]; then
+	# PKCE: code_verifier → code_challenge 생성
+	CODE_VERIFIER="dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+
+	# App 로그인 → authorization_code 받기
+	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
+		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-d "client_id=$APP_CLIENT_ID&redirect_uri=kr.econovation.eeos://callback&state=test456&email=$TEST_EMAIL&password=$TEST_PASSWORD&code_challenge=$CODE_CHALLENGE&code_challenge_method=S256")
+	STATUS=$(echo "$RESPONSE" | head -1)
+	REDIRECT_URL=$(echo "$RESPONSE" | tail -1)
+
+	if [ "$STATUS" -eq 303 ]; then
+		# redirect URL에서 code 추출
+		AUTH_CODE=$(echo "$REDIRECT_URL" | grep -oP 'code=\K[^&]+' || echo "")
+
+		if [ -n "$AUTH_CODE" ]; then
+			# 4-3a. 성공: code + code_verifier → AT/RT
+			RESPONSE=$(curl -s -w "\n%{http_code}" \
+				-X POST "$BASE_URL/api/auth/token" \
+				-H "Content-Type: application/x-www-form-urlencoded" \
+				-d "grant_type=authorization_code&code=$AUTH_CODE&code_verifier=$CODE_VERIFIER&redirect_uri=kr.econovation.eeos://callback&client_id=$APP_CLIENT_ID")
+			BODY=$(echo "$RESPONSE" | head -n -1)
+			STATUS=$(echo "$RESPONSE" | tail -1)
+			assert_status "4-3a. APP PKCE 토큰 교환 → 200" 200 "$STATUS" "$BODY"
+			assert_contains "4-3b. access_token 존재" "access_token" "$BODY"
+			assert_contains "4-3c. refresh_token 존재" "refresh_token" "$BODY"
+			assert_contains "4-3d. token_type Bearer" "Bearer" "$BODY"
+
+			# 토큰 저장 (reissue/logout 테스트용)
+			APP_ACCESS_TOKEN=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null || echo "")
+			APP_REFRESH_TOKEN=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['refresh_token'])" 2>/dev/null || echo "")
+
+			# 4-4. 실패: 같은 code 재사용 → 400
+			RESPONSE=$(curl -s -w "\n%{http_code}" \
+				-X POST "$BASE_URL/api/auth/token" \
+				-H "Content-Type: application/x-www-form-urlencoded" \
+				-d "grant_type=authorization_code&code=$AUTH_CODE&code_verifier=$CODE_VERIFIER&redirect_uri=kr.econovation.eeos://callback&client_id=$APP_CLIENT_ID")
+			STATUS=$(echo "$RESPONSE" | tail -1)
+			assert_status "4-4. code 재사용 → 400 (일회성)" 400 "$STATUS"
+
+		else
+			echo -e "${RED}[FAIL]${NC} 4-3. redirect URL에서 code 추출 실패: $REDIRECT_URL"
+			FAIL=$((FAIL + 1))
+			TOTAL=$((TOTAL + 1))
+		fi
+	else
+		echo -e "${RED}[FAIL]${NC} 4-3. APP 로그인 실패 (status=$STATUS)"
+		FAIL=$((FAIL + 1))
+		TOTAL=$((TOTAL + 1))
+	fi
+
+	# 4-5. 실패: PKCE code_verifier 불일치
+	# 새 code 발급
+	RESPONSE=$(curl -s -o /dev/null -w "%{http_code}\n%{redirect_url}" \
+		-X POST "$BASE_URL/api/auth/login/oauth2" \
+		-d "client_id=$APP_CLIENT_ID&redirect_uri=kr.econovation.eeos://callback&state=test789&email=$TEST_EMAIL&password=$TEST_PASSWORD&code_challenge=$CODE_CHALLENGE&code_challenge_method=S256")
+	STATUS=$(echo "$RESPONSE" | head -1)
+	REDIRECT_URL=$(echo "$RESPONSE" | tail -1)
+
+	if [ "$STATUS" -eq 303 ]; then
+		AUTH_CODE=$(echo "$REDIRECT_URL" | grep -oP 'code=\K[^&]+' || echo "")
+		if [ -n "$AUTH_CODE" ]; then
+			RESPONSE=$(curl -s -w "\n%{http_code}" \
+				-X POST "$BASE_URL/api/auth/token" \
+				-H "Content-Type: application/x-www-form-urlencoded" \
+				-d "grant_type=authorization_code&code=$AUTH_CODE&code_verifier=wrong_verifier_value&redirect_uri=kr.econovation.eeos://callback&client_id=$APP_CLIENT_ID")
+			STATUS=$(echo "$RESPONSE" | tail -1)
+			assert_status "4-5. PKCE verifier 불일치 → 400" 400 "$STATUS"
+		fi
+	fi
+else
+	echo -e "${YELLOW}[SKIP]${NC} APP PKCE 플로우: APP_CLIENT_ID 또는 TEST_EMAIL 미설정"
+fi
+
+# ============================================
+# 5. /reissue 엔드포인트
+# ============================================
+echo ""
+echo -e "${YELLOW}--- 5. /reissue 엔드포인트 ---${NC}"
+
+# 5-1. 실패: RT 없음 → 401
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+	-X POST "$BASE_URL/api/auth/reissue")
+STATUS=$(echo "$RESPONSE" | tail -1)
+assert_status "5-1. RT 없음 → 401" 401 "$STATUS"
+
+# 5-2. 실패: 잘못된 RT → 401
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+	-X POST "$BASE_URL/api/auth/reissue" \
+	-H "Cookie: eeos_refresh_token=invalid_token_value")
+STATUS=$(echo "$RESPONSE" | tail -1)
+assert_status "5-2. 잘못된 RT 쿠키 → 401" 401 "$STATUS"
+
+# ============================================
+# 6. /logout 엔드포인트
+# ============================================
+echo ""
+echo -e "${YELLOW}--- 6. /logout 엔드포인트 ---${NC}"
+
+# 6-1. 실패: 인증 없이 → 401
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+	-X POST "$BASE_URL/api/auth/logout")
+STATUS=$(echo "$RESPONSE" | tail -1)
+assert_status "6-1. 인증 없이 logout → 401" 401 "$STATUS"
+
+# ============================================
+# 결과 요약
+# ============================================
+echo ""
+echo "======================================"
+echo -e " 결과: ${GREEN}PASS=$PASS${NC} / ${RED}FAIL=$FAIL${NC} / TOTAL=$TOTAL"
+echo "======================================"
+
+if [ "$FAIL" -gt 0 ]; then
+	exit 1
+fi

--- a/scripts/api-test/test-login-flow.sh
+++ b/scripts/api-test/test-login-flow.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# 로그인/회원가입 플로우 curl 스모크 테스트
+#
+# 사전 준비:
+#   1. 로컬 서버 실행: cd eeos && ./gradlew bootRun
+#   2. 테스트 클라이언트 DB seed:
+#      mysql -u root -p eeos < scripts/api-test/seed-test-client.sql
+#
+# 사용법:
+#   ./scripts/api-test/test-login-flow.sh
+#   ./scripts/api-test/test-login-flow.sh http://localhost:8080
+
+BASE_URL="${1:-http://localhost:8080}"
+CLIENT_ID="test-web-client-id"
+REDIRECT_URI="http://localhost:3000/callback"
+STATE="test-state-$(date +%s)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; PASS=$((PASS+1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; echo "       $2"; FAIL=$((FAIL+1)); }
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+echo ""
+echo "=============================="
+echo " 로그인/회원가입 플로우 테스트"
+echo " $BASE_URL"
+echo "=============================="
+
+# ─────────────────────────────────────
+# 1. 회원가입
+# ─────────────────────────────────────
+echo ""
+info "1. 회원가입"
+
+SIGNUP_BODY=$(curl -s -w "\n%{http_code}" \
+  -X POST "$BASE_URL/api/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "testuser01",
+    "password": "test1234",
+    "generation": 1,
+    "name": "테스트유저",
+    "activeStatus": "am"
+  }')
+SIGNUP_STATUS=$(echo "$SIGNUP_BODY" | tail -1)
+SIGNUP_RESP=$(echo "$SIGNUP_BODY" | head -n -1)
+
+if [ "$SIGNUP_STATUS" -eq 201 ]; then
+  pass "1-1. 회원가입 성공 (201)"
+elif [ "$SIGNUP_STATUS" -eq 409 ]; then
+  info "1-1. 이미 가입된 계정 (409) - 계속 진행"
+  PASS=$((PASS+1))
+else
+  fail "1-1. 회원가입 실패" "HTTP $SIGNUP_STATUS / $SIGNUP_RESP"
+fi
+
+# 실패: 비밀번호 규칙 위반
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$BASE_URL/api/auth/signup" \
+  -H "Content-Type: application/json" \
+  -d '{"id":"bad","password":"1234","generation":1,"name":"테스트","activeStatus":"am"}')
+[ "$STATUS" -eq 400 ] && pass "1-2. 비밀번호 규칙 위반 → 400" || fail "1-2. 비밀번호 규칙 위반" "HTTP $STATUS"
+
+# ─────────────────────────────────────
+# 2. /authorize 검증
+# ─────────────────────────────────────
+echo ""
+info "2. /authorize 검증"
+
+# 성공: 로그인 페이지로 redirect
+AUTH_RESP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X GET "$BASE_URL/api/auth/authorize?client_id=$CLIENT_ID&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$REDIRECT_URI'))")&response_type=code&state=$STATE")
+[ "$AUTH_RESP" -eq 302 ] && pass "2-1. /authorize 로그인 페이지 redirect (302)" || fail "2-1. /authorize redirect 실패" "HTTP $AUTH_RESP"
+
+# 실패: 잘못된 client_id
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X GET "$BASE_URL/api/auth/authorize?client_id=invalid&redirect_uri=http://x.com&response_type=code&state=s")
+[ "$STATUS" -eq 400 ] && pass "2-2. 잘못된 client_id → 400" || fail "2-2. 잘못된 client_id" "HTTP $STATUS"
+
+# 실패: response_type != code
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X GET "$BASE_URL/api/auth/authorize?client_id=$CLIENT_ID&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$REDIRECT_URI'))")&response_type=token&state=s")
+[ "$STATUS" -eq 400 ] && pass "2-3. response_type=token → 400" || fail "2-3. response_type=token" "HTTP $STATUS"
+
+# ─────────────────────────────────────
+# 3. /login (WEB 플로우)
+# ─────────────────────────────────────
+echo ""
+info "3. /login WEB 플로우"
+
+# 성공: 로그인 → 303 + 쿠키
+LOGIN_RESP=$(curl -s -D - -o /dev/null \
+  -X POST "$BASE_URL/api/auth/login" \
+  -d "client_id=$CLIENT_ID&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$REDIRECT_URI'))")&state=$STATE&email=testuser01&password=test1234")
+
+LOGIN_STATUS=$(echo "$LOGIN_RESP" | grep "HTTP/" | awk '{print $2}' | tail -1)
+HAS_AT=$(echo "$LOGIN_RESP" | grep -i "eeos_access_token")
+HAS_RT=$(echo "$LOGIN_RESP" | grep -i "eeos_refresh_token")
+LOCATION=$(echo "$LOGIN_RESP" | grep -i "location:" | head -1)
+
+if [ "$LOGIN_STATUS" = "303" ]; then
+  pass "3-1. WEB 로그인 → 303 redirect"
+else
+  fail "3-1. WEB 로그인" "HTTP $LOGIN_STATUS"
+fi
+
+[ -n "$HAS_AT" ] && pass "3-2. eeos_access_token 쿠키 존재" || fail "3-2. eeos_access_token 쿠키 없음" "$LOGIN_RESP"
+[ -n "$HAS_RT" ] && pass "3-3. eeos_refresh_token 쿠키 존재" || fail "3-3. eeos_refresh_token 쿠키 없음" ""
+
+if echo "$LOCATION" | grep -q "state=$STATE"; then
+  pass "3-4. redirect Location에 state 포함"
+else
+  fail "3-4. redirect Location에 state 없음" "$LOCATION"
+fi
+
+# 실패: 잘못된 비밀번호 → 303 (로그인 페이지로 돌아감)
+BAD_LOGIN=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$BASE_URL/api/auth/login" \
+  -d "client_id=$CLIENT_ID&redirect_uri=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$REDIRECT_URI'))")&state=$STATE&email=testuser01&password=wrongpass")
+[ "$BAD_LOGIN" -eq 303 ] && pass "3-5. 잘못된 비밀번호 → 303 (로그인 페이지)" || fail "3-5. 잘못된 비밀번호" "HTTP $BAD_LOGIN"
+
+# 실패: redirect_uri 불일치 → 400
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$BASE_URL/api/auth/login" \
+  -d "client_id=$CLIENT_ID&redirect_uri=http://evil.com&state=$STATE&email=testuser01&password=test1234")
+[ "$STATUS" -eq 400 ] && pass "3-6. redirect_uri 불일치 → 400" || fail "3-6. redirect_uri 불일치" "HTTP $STATUS"
+
+# ─────────────────────────────────────
+# 결과
+# ─────────────────────────────────────
+echo ""
+echo "=============================="
+echo -e " ${GREEN}PASS=$PASS${NC} / ${RED}FAIL=$FAIL${NC} / TOTAL=$((PASS+FAIL))"
+echo "=============================="
+[ "$FAIL" -gt 0 ] && exit 1 || exit 0


### PR DESCRIPTION
## 개요

`auth.econovation.kr`에서 Web과 App 클라이언트의 인증 흐름을 분리합니다.
- **Web**: 쿠키(AT/RT) 기반, 로그인 후 redirect
- **App**: OAuth2 Authorization Code + PKCE, 토큰은 JSON body 반환

---

## 변경 사항

### 새 엔드포인트

| Method | Path | 설명 |
|--------|------|------|
| POST | `/api/auth/clients` | OAuth2 클라이언트 등록 (관리자) |
| GET | `/api/auth/authorize` | 인증 진입점, 로그인 페이지로 redirect |
| POST | `/api/auth/login` | 로그인 인증 + Web/App 분기 |
| POST | `/api/auth/token` | App: authorization_code → AT/RT 교환 |

### 핵심 구현

- **ClientEntity** — Web/App 클라이언트 등록 및 redirect_uri 관리 (최대 10개, URI당 512자)
- **PkceValidator** — S256 방식 PKCE 검증
- **AuthorizationCodeRepository** — Redis TTL 60초, 일회용 authorization_code
- **LoginRateLimiter** — IP당 분당 20회, 계정당 5회 연속 실패 시 5분 lockout
- **OAuth2LoginService** — Web/App 분기 로그인 처리
- **TokenExchangeService** — code + code_verifier + redirect_uri 검증 후 토큰 발급

### 보안

- RT 발급 시 `clientType`, `clientId` 클레임 포함 → reissue/logout 분기 기준
- 쿠키 SameSite: `None` → `Lax` 변경
- AT 쿠키: `eeos_access_token` (Path: `/api`), RT 쿠키: `eeos_refresh_token` (Path: `/api/auth`)
- redirect_uri 불일치 시 redirect 없이 즉시 400 반환 (open redirect 방지)

### 기존 엔드포인트

| Method | Path | 상태 |
|--------|------|------|
| POST | `/api/auth/login/{oauthServerType}` | 유지 (Slack OAuth) |
| POST | `/api/auth/reissue` | RT 내부 clientType으로 Web/App 분기 추가 |
| POST | `/api/auth/logout` | RT 내부 clientType으로 Web/App 분기 추가 |

---

## DB 마이그레이션

`V1.00.0.4__create_oauth_client_tables.sql`
- `oauth_client` 테이블 추가
- `oauth_client_redirect_uri` 테이블 추가

---

## 테스트

- 단위 테스트: `ClientServiceTest`, `PkceValidatorTest`, `TokenProviderTest`, `OAuth2LoginServiceTest`, `TokenExchangeServiceTest`
- 스모크 테스트 스크립트: `scripts/api-test/test-login-flow.sh`

```bash
# 로컬 검증
mysql -u root -p eeos < scripts/api-test/seed-test-client.sql
./scripts/api-test/test-login-flow.sh http://localhost:8080
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Web과 App 클라이언트를 위한 별도의 OAuth2 인증 흐름 추가
  * OAuth2 클라이언트 등록 API 추가
  * PKCE(Proof Key for Code Exchange) 지원으로 App 클라이언트 보안 강화
  * 로그인 시도에 대한 레이트 제한 및 계정 잠금 기능 추가

* **Improvements**
  * 쿠키의 SameSite 속성을 None에서 Lax로 변경하여 보안 개선
  * Web 클라이언트를 위한 Access/Refresh 토큰 분리 저장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->