### PR TITLE
fix: oauth_client_client_type 컬럼 타입 VARCHAR → ENUM 변경으로 Hibernate 스키마 검증 오류 해결

### DIFF
--- a/eeos/src/main/resources/db/migration/V1.00.0.7__alter_oauth_client_type_to_enum.sql
+++ b/eeos/src/main/resources/db/migration/V1.00.0.7__alter_oauth_client_type_to_enum.sql
@@ -1,0 +1,4 @@
+-- oauth_client_client_type 컬럼을 VARCHAR에서 ENUM으로 변경
+-- V1.00.0.6 이 VARCHAR로 적용된 환경 대응
+ALTER TABLE oauth_client
+    MODIFY COLUMN oauth_client_client_type ENUM('WEB','APP') NOT NULL;


### PR DESCRIPTION
## 개요
`feat: Web/App 인증 분리 + PKCE 도입 (#328)` 에서 생성된 `oauth_client` 테이블의 `oauth_client_client_type` 컬럼이 `VARCHAR(10)`으로 생성되었으나, Hibernate 6+는 `@Enumerated(EnumType.STRING)`을 MySQL `ENUM` 타입으로 기대하여 스키마 검증 오류가 발생합니다.

## 변경 사항
- `V1.00.0.7__alter_oauth_client_type_to_enum.sql` 추가
  - `oauth_client_client_type` 컬럼을 `VARCHAR(10)` → `ENUM('WEB','APP')`으로 변경

## 테스트
- [x] 애플리케이션 기동 시 Flyway 마이그레이션 정상 완료 확인
- [x] Hibernate 스키마 검증 오류 없이 애플리케이션 정상 기동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* OAuth 클라이언트 데이터 저장소의 데이터 무결성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->