### PR TITLE
feat: v1/v2 인증 분리 + Client-Type 헤더 기반 Web/App 분기

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/converter/TokenResponseConverter.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/converter/TokenResponseConverter.java
@@ -11,4 +11,12 @@ public class TokenResponseConverter {
 				.accessExpiredTime(accessExpiredTime)
 				.build();
 	}
+
+	public TokenResponse from(String accessToken, Long accessExpiredTime, String refreshToken) {
+		return TokenResponse.builder()
+				.accessToken(accessToken)
+				.accessExpiredTime(accessExpiredTime)
+				.refreshToken(refreshToken)
+				.build();
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/response/TokenResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/dto/response/TokenResponse.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.auth.application.dto.response;
 
 import com.blackcompany.eeos.common.support.dto.AbstractResponseDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TokenResponse implements AbstractResponseDto {
 	private String accessToken;
 	private Long accessExpiredTime;
+	private String refreshToken;
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/ClientController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/ClientController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/auth/clients")
+@RequestMapping("/api/v2/auth/clients")
 @RequiredArgsConstructor
 public class ClientController implements ClientApi {
 

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v2/auth")
 @RequiredArgsConstructor
 public class OAuth2Controller implements OAuth2Api {
 

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/V1LoginController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/V1LoginController.java
@@ -1,0 +1,63 @@
+package com.blackcompany.eeos.auth.presentation.controller;
+
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
+import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
+import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
+import com.blackcompany.eeos.auth.application.usecase.LoginUsecase;
+import com.blackcompany.eeos.auth.presentation.docs.V1AuthApi;
+import com.blackcompany.eeos.auth.presentation.support.AuthConstants;
+import com.blackcompany.eeos.auth.presentation.support.AuthCookieManager;
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseGenerator;
+import com.blackcompany.eeos.common.presentation.response.MessageCode;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class V1LoginController implements V1AuthApi {
+
+	private final LoginUsecase loginUsecase;
+	private final AuthCookieManager cookieManager;
+	private final TokenResponseConverter tokenResponseConverter;
+
+	@Override
+	@PostMapping("/login")
+	public ApiResponse<SuccessBody<TokenResponse>> login(
+			@RequestHeader(value = "Client-Type", defaultValue = "WEB") String clientType,
+			@RequestBody EEOSLoginRequest request,
+			HttpServletResponse httpResponse) {
+
+		TokenModel tokenModel = loginUsecase.login(request.getId(), request.getPassword());
+
+		if ("APP".equalsIgnoreCase(clientType)) {
+			// APP: AT + RT 모두 body
+			TokenResponse response =
+					tokenResponseConverter.from(
+							tokenModel.getAccessToken(),
+							tokenModel.getAccessExpiredTime(),
+							tokenModel.getRefreshToken());
+			return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
+		}
+
+		// WEB (기본): RT 쿠키 + AT body
+		TokenResponse response =
+				tokenResponseConverter.from(tokenModel.getAccessToken(), tokenModel.getAccessExpiredTime());
+		ResponseCookie cookie =
+				cookieManager.setCookie(AuthConstants.TOKEN_KEY, tokenModel.getRefreshToken());
+		httpResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/V1AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/V1AuthApi.java
@@ -1,0 +1,40 @@
+package com.blackcompany.eeos.auth.presentation.docs;
+
+import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
+import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "v1 인증", description = "단순 로그인 API (Client-Type 헤더로 Web/App 분기)")
+public interface V1AuthApi {
+
+	@Operation(
+			summary = "v1 로그인",
+			description =
+					"id/password로 로그인한다. Client-Type 헤더로 Web/App을 구분한다.\n\n"
+							+ "- **WEB**: RT는 쿠키, AT는 body 반환\n"
+							+ "- **APP**: AT + RT 모두 body 반환 (쿠키 없음)")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "201",
+				description = "로그인 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "401",
+				description = "| 코드 | 메시지 |\n" + "|------|--------|\n" + "| 4008 | ID 또는 비밀번호가 일치하지 않습니다 |",
+				content = @Content)
+	})
+	ApiResponse<SuccessBody<TokenResponse>> login(
+			@Parameter(description = "클라이언트 타입 (WEB 또는 APP, 기본값: WEB)", example = "WEB")
+					@RequestHeader(value = "Client-Type", defaultValue = "WEB")
+					String clientType,
+			@Parameter(description = "로그인 요청 정보", required = true) @RequestBody EEOSLoginRequest request,
+			HttpServletResponse httpResponse);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/config/security/SecurityFilterChainConfig.java
@@ -72,9 +72,13 @@ public class SecurityFilterChainConfig {
 							.requestMatchers(HttpMethod.POST, "/api/auth/signup")
 							.requestMatchers(HttpMethod.POST, "/api/auth/reissue")
 							.requestMatchers(HttpMethod.POST, "/api/slack/events")
-							.requestMatchers(HttpMethod.GET, "/api/auth/authorize")
-							.requestMatchers(HttpMethod.POST, "/api/auth/token")
-							.requestMatchers(HttpMethod.POST, "/api/auth/clients")
+							// v1
+							.requestMatchers(HttpMethod.POST, "/api/v1/auth/login")
+							// v2 (OAuth2 흐름)
+							.requestMatchers(HttpMethod.GET, "/api/v2/auth/authorize")
+							.requestMatchers(HttpMethod.POST, "/api/v2/auth/login")
+							.requestMatchers(HttpMethod.POST, "/api/v2/auth/token")
+							.requestMatchers(HttpMethod.POST, "/api/v2/auth/clients")
 							.requestMatchers("/api/guest/**")
 							.requestMatchers("/api/health-check");
 				});

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/V1LoginControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/V1LoginControllerTest.java
@@ -1,0 +1,107 @@
+package com.blackcompany.eeos.auth.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
+import com.blackcompany.eeos.auth.application.usecase.LoginUsecase;
+import com.blackcompany.eeos.auth.presentation.support.AuthCookieManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class V1LoginControllerTest {
+
+	MockMvc mockMvc;
+	ObjectMapper objectMapper = new ObjectMapper();
+
+	@Mock LoginUsecase loginUsecase;
+	@Mock AuthCookieManager cookieManager;
+	@Spy TokenResponseConverter tokenResponseConverter;
+	@InjectMocks V1LoginController v1LoginController;
+
+	private final TokenModel tokenModel =
+			TokenModel.builder()
+					.accessToken("test-at")
+					.refreshToken("test-rt")
+					.accessExpiredTime(9999999L)
+					.refreshExpiredTime(9999999L)
+					.build();
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(v1LoginController).build();
+	}
+
+	@Test
+	@DisplayName("WEB: Client-Type 헤더가 WEB이면 AT만 body에 반환하고 refreshToken은 없다")
+	void shouldNotIncludeRefreshTokenInBodyWhenWebClientType() throws Exception {
+		given(loginUsecase.login(eq("testuser"), eq("test1234"))).willReturn(tokenModel);
+		given(cookieManager.setCookie(any(), any()))
+				.willReturn(ResponseCookie.from("eeos_token", "test-rt").build());
+
+		mockMvc
+				.perform(
+						post("/api/v1/auth/login")
+								.header("Client-Type", "WEB")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(
+										objectMapper.writeValueAsString(
+												Map.of("id", "testuser", "password", "test1234"))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.accessToken").value("test-at"))
+				.andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("APP: Client-Type 헤더가 APP이면 AT+RT 모두 body에 반환한다")
+	void shouldReturnBothTokensInBodyWhenAppClientType() throws Exception {
+		given(loginUsecase.login(eq("testuser"), eq("test1234"))).willReturn(tokenModel);
+
+		mockMvc
+				.perform(
+						post("/api/v1/auth/login")
+								.header("Client-Type", "APP")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(
+										objectMapper.writeValueAsString(
+												Map.of("id", "testuser", "password", "test1234"))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.accessToken").value("test-at"))
+				.andExpect(jsonPath("$.data.refreshToken").value("test-rt"));
+	}
+
+	@Test
+	@DisplayName("Client-Type 헤더가 없으면 WEB으로 처리한다")
+	void shouldDefaultToWebWhenNoClientTypeHeader() throws Exception {
+		given(loginUsecase.login(any(), any())).willReturn(tokenModel);
+		given(cookieManager.setCookie(any(), any()))
+				.willReturn(ResponseCookie.from("eeos_token", "test-rt").build());
+
+		mockMvc
+				.perform(
+						post("/api/v1/auth/login")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(
+										objectMapper.writeValueAsString(
+												Map.of("id", "testuser", "password", "test1234"))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+	}
+}


### PR DESCRIPTION
## 개요

기존 OAuth2 흐름(PR #328)을 v2로 분리하고, 현재 사용 가능한 단순 v1 로그인을 추가합니다.

---

## 변경 사항

### v1 — 단순 로그인 (신규)

```
POST /api/v1/auth/login
Client-Type: WEB   ← 헤더로 구분 (기본값: WEB)
Content-Type: application/json

{ "id": "...", "password": "..." }
```

| Client-Type | 응답 |
|-------------|------|
| WEB (기본)  | RT → 쿠키, AT → body |
| APP         | AT + RT → body (쿠키 없음) |

### v2 — OAuth2 흐름 (기존 경로 변경)

기존 PR #328의 엔드포인트를 `/api/v2/auth/*`로 이동:
- `GET /api/auth/authorize` → `GET /api/v2/auth/authorize`
- `POST /api/auth/login` (OAuth2) → `POST /api/v2/auth/login`
- `POST /api/auth/token` → `POST /api/v2/auth/token`
- `POST /api/auth/clients` → `POST /api/v2/auth/clients`

---

## curl 검증 결과

```bash
# WEB: RT 쿠키 + AT body
curl -X POST /api/v1/auth/login \
  -H "Client-Type: WEB" \
  -d '{"id":"user","password":"pass"}'
# → Set-Cookie: eeos_token=... + {"accessToken":"..."}

# APP: AT + RT 모두 body
curl -X POST /api/v1/auth/login \
  -H "Client-Type: APP" \
  -d '{"id":"user","password":"pass"}'
# → {"accessToken":"...","refreshToken":"..."}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **새로운 기능**
  * 새로운 v1 로그인 엔드포인트 추가로 클라이언트 타입별 차별화된 인증 처리 지원
  * 리프레시 토큰 기능 도입으로 토큰 갱신 지원
  * 웹 클라이언트는 보안 쿠키로 리프레시 토큰 수신, 앱 클라이언트는 응답 본문으로 수신

* **테스트**
  * 클라이언트 타입별 로그인 시나리오 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->