### PR TITLE
[REFACTOR] 모니터링 분리 및 apk 오류 해결, 알림 분기 처리

### DIFF
--- a/eeos/docker-compose-dev.yml
+++ b/eeos/docker-compose-dev.yml
@@ -81,49 +81,7 @@ services:
       - internal-network
       - external-network
 
-  # Monitoring Stack
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml.template:ro
-      - prometheus-data:/prometheus
-    environment:
-      - PROD_SERVER_IP=${PROD_SERVER_IP}
-    entrypoint: /bin/sh
-    command: >
-      -c "apk add --no-cache gettext && envsubst '$$PROD_SERVER_IP' < /etc/prometheus/prometheus.yml.template > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle"
-    restart: always
-    networks:
-      - internal-network
-      - external-network
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_USERS_ALLOW_SIGN_UP=false
-      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
-    volumes:
-      - grafana-data:/var/lib/grafana
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
-    depends_on:
-      - prometheus
-    restart: always
-    networks:
-      - internal-network
-      - external-network
-
 networks:
   internal-network:
   external-network:
 
-volumes:
-  prometheus-data:
-  grafana-data:

--- a/eeos/docker-compose-dev.yml
+++ b/eeos/docker-compose-dev.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./proxy/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
     environment:
-      - DEV_SERVER_IP=${DEV_SERVER_IP}
+      - DEV_SERVER_IP=${DEV_SERVER_IP:?DEV_SERVER_IP is required}
     restart: always
     networks:
       - external-network

--- a/eeos/docker-compose-monitoring.yml
+++ b/eeos/docker-compose-monitoring.yml
@@ -11,7 +11,7 @@ services:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml.template:ro
       - prometheus-data:/prometheus
     environment:
-      - PROD_SERVER_IP=${PROD_SERVER_IP}
+      - PROD_SERVER_IP=${PROD_SERVER_IP:?PROD_SERVER_IP is required}
     entrypoint: /bin/sh
     command: >
       -c "envsubst '$$PROD_SERVER_IP' < /etc/prometheus/prometheus.yml.template > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle"
@@ -26,10 +26,10 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:?GRAFANA_ADMIN_USER is required}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
       - GF_USERS_ALLOW_SIGN_UP=false
-      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:?SLACK_WEBHOOK_URL is required}
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -41,11 +41,7 @@ services:
       - external-network
 networks:
   internal-network:
-    external:
-      name: eeos_internal-network
   external-network:
-    external:
-      name: eeos_external-network
 
 volumes:
   prometheus-data:

--- a/eeos/docker-compose-monitoring.yml
+++ b/eeos/docker-compose-monitoring.yml
@@ -26,8 +26,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
     volumes:

--- a/eeos/docker-compose-monitoring.yml
+++ b/eeos/docker-compose-monitoring.yml
@@ -1,0 +1,52 @@
+version: '3.1'
+services:
+  prometheus:
+    build:
+      context: ./monitoring
+      dockerfile: Dockerfile.prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml.template:ro
+      - prometheus-data:/prometheus
+    environment:
+      - PROD_SERVER_IP=${PROD_SERVER_IP}
+    entrypoint: /bin/sh
+    command: >
+      -c "envsubst '$$PROD_SERVER_IP' < /etc/prometheus/prometheus.yml.template > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle"
+    restart: always
+    networks:
+      - internal-network
+      - external-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    restart: always
+    networks:
+      - internal-network
+      - external-network
+networks:
+  internal-network:
+    external:
+      name: eeos_internal-network
+  external-network:
+    external:
+      name: eeos_external-network
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/eeos/docker-compose-prod.yml
+++ b/eeos/docker-compose-prod.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./proxy/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
     environment:
-      - DEV_SERVER_IP=${DEV_SERVER_IP}
+      - DEV_SERVER_IP=${DEV_SERVER_IP:?DEV_SERVER_IP is required}
     command: >
       /bin/sh -c "envsubst '$$DEV_SERVER_IP' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
     restart: always

--- a/eeos/docker-compose-prod.yml
+++ b/eeos/docker-compose-prod.yml
@@ -8,7 +8,11 @@ services:
     ports:
       - "50001:80"
     volumes:
-      - ./proxy/nginx.conf:/etc/nginx/nginx.conf
+      - ./proxy/nginx.conf:/etc/nginx/templates/nginx.conf.template:ro
+    environment:
+      - DEV_SERVER_IP=${DEV_SERVER_IP}
+    command: >
+      /bin/sh -c "envsubst '$$DEV_SERVER_IP' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
     restart: always
     networks:
       - external-network

--- a/eeos/monitoring/Dockerfile.prometheus
+++ b/eeos/monitoring/Dockerfile.prometheus
@@ -1,0 +1,7 @@
+FROM alpine:latest as builder
+RUN apk add --no-cache gettext
+
+FROM prom/prometheus:latest
+COPY --from=builder /usr/bin/envsubst /usr/bin/envsubst
+COPY --from=builder /usr/lib/libintl.so.8 /usr/lib/libintl.so.8
+COPY --from=builder /lib/ld-musl-* /lib/

--- a/eeos/monitoring/grafana/provisioning/alerting/alerting.yml
+++ b/eeos/monitoring/grafana/provisioning/alerting/alerting.yml
@@ -11,9 +11,10 @@ contactPoints:
           title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
           text: |
             {{ range .Alerts }}
-            *Alert:* {{ .Annotations.summary }}
-            *Description:* {{ .Annotations.description }}
-            *Severity:* {{ .Labels.severity }}
+            *상태:* {{ if eq .Status "firing" }}🔴 발생{{ else }}✅ 해제{{ end }}
+            *요약:* {{ .Annotations.summary }}
+            *상세:* {{ .Annotations.description }}
+            *심각도:* {{ .Labels.severity }}
             {{ end }}
 
 policies:
@@ -37,8 +38,8 @@ groups:
         noDataState: Alerting
         execErrState: Alerting
         annotations:
-          summary: 'EEOS 서비스 다운'
-          description: '{{ $labels.job }} 서비스가 응답하지 않습니다. (instance: {{ $labels.instance }})'
+          summary: "EEOS 서비스 상태 이상"
+          description: "{{ if $labels.job }}{{ $labels.job }}{{ else }}EEOS 관련{{ end }} 서비스가 응답하지 않습니다. (instance: {{ $labels.instance | default \"알 수 없음\" }})"
         labels:
           severity: critical
         data:

--- a/eeos/monitoring/grafana/provisioning/alerting/alerting.yml
+++ b/eeos/monitoring/grafana/provisioning/alerting/alerting.yml
@@ -1,5 +1,16 @@
 apiVersion: 1
 
+templates:
+  - name: slack_message
+    template: |
+      {{ range .Alerts }}
+      *환경:* {{ .Labels.environment }}
+      *상태:* {{ if eq .Status "firing" }}🔴중단발생{{ else }}✅ 해제{{ end }}
+      *대상:* {{ .Labels.job }}
+      *인스턴스:* {{ .Labels.instance }}
+      *심각도:* {{ .Labels.severity }}
+      {{ end }}
+
 contactPoints:
   - orgId: 1
     name: Slack
@@ -9,13 +20,7 @@ contactPoints:
         settings:
           url: ${SLACK_WEBHOOK_URL}
           title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
-          text: |
-            {{ range .Alerts }}
-            *상태:* {{ if eq .Status "firing" }}🔴 발생{{ else }}✅ 해제{{ end }}
-            *요약:* {{ .Annotations.summary }}
-            *상세:* {{ .Annotations.description }}
-            *심각도:* {{ .Labels.severity }}
-            {{ end }}
+          text: '{{ template "slack_message" . }}'
 
 policies:
   - orgId: 1
@@ -38,8 +43,8 @@ groups:
         noDataState: Alerting
         execErrState: Alerting
         annotations:
-          summary: "EEOS 서비스 상태 이상"
-          description: "{{ if $labels.job }}{{ $labels.job }}{{ else }}EEOS 관련{{ end }} 서비스가 응답하지 않습니다. (instance: {{ $labels.instance | default \"알 수 없음\" }})"
+          summary: 'EEOS 서비스 장애 발생'
+          description: '서비스 상태를 확인하세요.'
         labels:
           severity: critical
         data:
@@ -59,10 +64,51 @@ groups:
             model:
               type: threshold
               refId: C
+              expression: A
               conditions:
                 - evaluator:
                     params: [1]
                     type: lt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+
+      - uid: eeos-service-restarting
+        title: 'EEOS Service Restarting'
+        condition: C
+        for: 0s
+        noDataState: NoData
+        execErrState: Alerting
+        annotations:
+          summary: 'EEOS 서비스 재시작 반복 중'
+          description: '서비스 상태를 확인하세요.'
+        labels:
+          severity: warning
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: 'changes(up{job=~"eeos.*"}[5m])'
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator:
+                    params: [2]
+                    type: gt
                   operator:
                     type: and
                   query:

--- a/eeos/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/eeos/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -5,6 +5,6 @@ datasources:
     type: prometheus
     uid: prometheus
     access: proxy
-    url: https://prometheus:9090
+    url: http://prometheus:9090
     isDefault: true
     editable: false

--- a/eeos/scripts/deploy-develop.sh
+++ b/eeos/scripts/deploy-develop.sh
@@ -7,7 +7,7 @@ git reset --hard origin/develop
 
 ./gradlew build -x test
 
-sudo docker-compose -f docker-compose-dev.yml down
+sudo docker-compose -f docker-compose-dev.yml --env-file .env down
 
-sudo docker-compose -f docker-compose-dev.yml up --build -d
+sudo docker-compose -f docker-compose-dev.yml --env-file .env up --build -d
 

--- a/eeos/scripts/deploy-product.sh
+++ b/eeos/scripts/deploy-product.sh
@@ -7,7 +7,7 @@ git reset --hard origin/release
 
 ./gradlew build -x test
 
-sudo docker-compose -f docker-compose-prod.yml down
+sudo docker-compose -f docker-compose-prod.yml --env-file .env down
 
-sudo docker-compose -f docker-compose-prod.yml up --build -d
+sudo docker-compose -f docker-compose-prod.yml --env-file .env up --build -d
 


### PR DESCRIPTION
## 📌 관련 이슈
closes #326 
## ✒️ 작업 내용
1. 모니터링계층 분리 (docker-compose-monitoring.yml)
2. apk 오류 -> 멀티 스테이지 빌드를 적용하여 해결했습니다.
3. 알림 분기 처리 -> 개발용 :  development / eeos-dev, 운영용 : production / eeos-prod 로 알림 하도록 처리했습니다.

### 그라파나 알림 룰 설명
> 총 2개의 알림 룰이 있습니다.
 1. EEOS Service Down                                                                                                                                                                                           
  - 조건: up{job=~"eeos.*"} < 1 — Prometheus scrape 실패 시                                                              
  - 발동: 2분 연속 다운 상태 유지 시 알림 전송
  - NoData: 데이터 수집 자체 불가 시에도 Alerting 처리                                                                   
  - 심각도: critical                                                                                                     
                                                                                                                         
  2. EEOS Service Restarting         
  - 조건: changes(up{job=~"eeos.*"}[5m]) > 2 — 5분 내 up 상태가 2번 이상 변경 시                                         
  - 발동: 즉시 (for: 0s)
  - 심각도: warning                                                                                                      
                                                                                                                           
  두 룰 모두 eeos-prod, eeos-dev job을 모니터링하며, 슬랙 모니터링 채널에 알림
                  
  **Slack 메시지 포맷**     
  환경: production / development                                                                                         
  상태: 🔴 중단발생 / ✅ 해제
  대상: eeos-prod / eeos-dev                                                                                             
  인스턴스: 서버 IP
  심각도: critical / warning  

## 💬 REVIEWER에게 공유사항 💬 
1. be 문서 -> .env 문서에 그라파나 계정 관련 환경변수 값 넣어두었습니다. (env.propertise 아님)
2. 멀티 스테이지 빌드 적용한 이유
- [문제] 환경변수(서버 주소)를 적용하기 위해 envsubst 설치 필요
prom/prometheus는 distroless 이미지(경량화)로 패키지 매니저가 없는 상태였습니다.
하지만 환경변수 치환을 위해서는 envsubst가 필요한 상황이었습니다.
- [해결] 멀티스테이지 빌드
Alpine 이미지에서 envsubst와 필수 라이브러리만 추출하여 prometheus 이미지에 복사하는 방식으로 해결했습니다. 이를 통해 distroless의 보안성과 경량성을 유지하면서 환경변수 기능을 추가할 수 있었습니다. (stage1 : 필수 라이브러리 복사, stage 2 : prometheus 빌드)
- 작업 기록 문서 : https://www.notion.so/docker-compose-apk-331348dfe77f80fda6e1c4da0a94e9e5?source=copy_link

ps.모니터링 관련 의견이 있다면 언제든 남겨주세요! 적용하겠습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 독립 모니터링 스택 추가(수집기 및 대시보드 포함).
  * 시작 시 템플릿 기반 동적 구성 생성으로 배포 유연성 향상.
  * 경고 템플릿 추가 및 재시작 알림 규칙 신설.

* **Chores**
  * 개발용 구성에서 모니터링 스택 및 관련 영구 스토리지 제거.
  * 모니터링 데이터 소스 연결 프로토콜을 HTTPS→HTTP로 변경.
  * 배포 스크립트가 환경파일(.env)을 명시적으로 사용하도록 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->