### PR TITLE
[FEAT] Slack 연동 회원가입 분기 및 가입 안내 DM 발송 추가

### DIFF
--- a/eeos/docs/auth_README.md
+++ b/eeos/docs/auth_README.md
@@ -1,0 +1,124 @@
+# Auth 도메인
+
+## 역할
+
+- `auth/presentation/controller/AuthController`는 `/api/auth`에서 회원가입, 토큰 재발급, 로그아웃, 회원탈퇴 API를 제공합니다.
+- `EeosSignUpUseCase`는 ID/PW 방식 회원가입 로직을 담당하며, 일반 가입/Slack 연동 가입을 메서드 오버로드로 분기합니다.
+- `OAuthSignUpUseCase`는 Slack OAuth2 로그인 후 추가 정보 입력을 통한 신규 회원 등록을 담당합니다.
+
+## API 명세
+
+### POST `/api/auth/signup`
+
+ID/PW 방식으로 회원가입하고 토큰을 발급합니다.
+`slackMemberId`를 포함하면 기존 Slack OAuth2 회원에 EEOS 계정을 연결합니다.
+
+- 인증: 불필요
+
+#### 요청
+
+```json
+{
+  "id": "econovation2025",
+  "password": "eeos1234",
+  "generation": 30,
+  "name": "김에코",
+  "activeStatus": "am",
+  "slackMemberId": "U08ABCDE123"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `id` | string | O | 로그인 아이디 (최대 50자) |
+| `password` | string | O | 비밀번호 (영문+숫자 조합 8~20자) |
+| `generation` | integer | O | 에코노베이션 기수 (1 이상) |
+| `name` | string | O | 회원 성함 (최대 50자) |
+| `activeStatus` | string | O | 활동 상태: `am`, `cm`, `rm`, `ob` 중 하나 |
+| `slackMemberId` | string | X | Slack 회원 ID. Slack OAuth2만 가입된 회원이 계정 연결 시 사용 |
+
+#### 동작 분기
+
+| `slackMemberId` 여부 | 동작 |
+|---------------------|------|
+| 없음 | 새 Member + Account 생성 (`EeosSignUpUseCase`) |
+| 있음 | 기존 Slack OAuth 회원에 Account 연결 (`EeosSignUpUseCase#signUp(command, slackMemberId)`) |
+
+#### 응답
+
+- `201 Created`: 회원가입 성공, 응답 바디에 accessToken 반환, 쿠키에 refreshToken 설정
+
+#### 오류
+
+| HTTP | 코드 | 메시지 |
+|------|------|--------|
+| 400 | 4100 | 아이디는 필수 입력값입니다 |
+| 400 | 4101 | 아이디는 50자 이하여야 합니다 |
+| 400 | 4102 | 비밀번호는 필수 입력값입니다 |
+| 400 | 4103 | 비밀번호는 8~20자이며, 영문과 숫자를 포함해야 합니다 |
+| 400 | 4104 | 기수는 필수 입력값입니다 |
+| 400 | 4105 | 기수는 1 이상이어야 합니다 |
+| 400 | 4106 | 성함은 필수 입력값입니다 |
+| 400 | 4107 | 성함은 50자 이하여야 합니다 |
+| 400 | 4108 | 활동 상태는 필수 입력값입니다 |
+| 400 | 4109 | 활동 상태는 am, cm, rm, ob 중 하나여야 합니다 |
+| 400 | 3001 | {status}는 존재하지 않는 활동 상태입니다 |
+| 404 | 4200 | 존재하지 않는 Slack 회원 ID입니다 |
+| 409 | 4201 | 이미 계정이 연결된 회원입니다 |
+| 409 | 4009 | 이미 사용 중인 아이디입니다 |
+
+---
+
+### POST `/api/auth/reissue`
+
+리프레시 토큰을 사용해 새로운 AT/RT를 발급합니다.
+
+- 인증: 쿠키 내 refreshToken 필요
+- Web 클라이언트: 새 AT/RT 쿠키를 재설정합니다.
+- App 클라이언트: 응답 바디에 accessToken을 반환합니다.
+
+#### 오류
+
+| HTTP | 코드 | 메시지 |
+|------|------|--------|
+| 401 | 4003 | 만료된 토큰입니다 |
+| 401 | 4004 | 블랙리스트에 등록된 토큰입니다 |
+
+---
+
+### POST `/api/auth/logout`
+
+리프레시 토큰을 블랙리스트에 등록하여 로그아웃합니다.
+
+- 인증: JWT 필수
+- Web 클라이언트: AT/RT 쿠키도 함께 삭제합니다.
+
+---
+
+### POST `/api/auth/withdraw`
+
+쿠키에 담긴 리프레시 토큰을 이용하여 회원을 탈퇴합니다.
+
+- 인증: JWT 필수
+
+---
+
+### POST `/api/auth/login/additional-info`
+
+Slack OAuth2 로그인 후 추가 정보(성함, 기수, 활동상태)를 제출하여 신규 회원으로 등록합니다.
+
+- 인증: `verificationId` 쿠키 필요 (OAuth 콜백 이후 발급)
+
+## 주요 정책
+
+1. **회원가입 분기**: `slackMemberId` 유무로 신규 가입과 Slack 연동 가입을 분기합니다.
+2. **Slack 연동 가입 검증**: `slackMemberId`가 DB에 없으면 4200, 이미 Account가 연결된 경우 4201 에러를 반환합니다.
+3. **클라이언트 타입 분기**: `Client-Type` 헤더 또는 refreshToken에 저장된 클라이언트 타입으로 Web/App을 구분하여 토큰 전달 방식을 결정합니다.
+4. **토큰 블랙리스트**: 로그아웃/탈퇴 시 Redis에 refreshToken을 블랙리스트로 등록해 재사용을 방지합니다.
+
+## 연관 컴포넌트
+
+- `auth/application/usecase/*` : `EeosSignUpUseCase`, `OAuthSignUpUseCase`, `LoginUsecase`, `ReissueUsecase`, `LogOutUsecase`, `WithDrawUsecase`
+- `auth/application/exception/AlreadyLinkedAccountException` : 에러 코드 4201
+- `auth/application/exception/SlackMemberNotFoundException` : 에러 코드 4200
+- `auth/presentation/dto/EeosSignUpRequest` : 회원가입 요청 DTO

--- a/eeos/docs/member_README.md
+++ b/eeos/docs/member_README.md
@@ -23,7 +23,48 @@
 - **인증 연계**: `CreateAdminMemberService`는 `AccountJpaRepository`, `AuthorityRepository`, `OAuthMemberRepository`와 연동해 멤버-계정-권한을 동시에 구성하고 `Role.ROLE_ADMIN` 권한을 부여합니다.
 - **검증 책임 분리**: Bean Validation(`ChangeActiveStatusRequest`, `ChangeDepartment` 파라미터)와 도메인 검증(`MemberModel.canEdit`)을 분리해 유지보수성을 높입니다.
 
+## API 명세 (추가 엔드포인트)
+
+### POST `/api/members/admin/slack-signup-dm`
+
+Slack OAuth2로만 가입된(EEOS ID/PW 계정이 없는) 회원 전체에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다.
+
+- 인증: JWT 필수 (관리자 권한)
+- 요청 본문: 없음
+
+#### 응답
+
+```json
+{
+  "totalCount": 12,
+  "successCount": 11,
+  "failCount": 1
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `totalCount` | int | DM 발송 대상 총 인원 수 |
+| `successCount` | int | DM 발송 성공 인원 수 |
+| `failCount` | int | DM 발송 실패 인원 수 |
+
+#### 오류
+
+| HTTP | 코드 | 메시지 |
+|------|------|--------|
+| 403 | 3000 | 관리자 권한이 없습니다 |
+
+#### 내부 흐름
+
+1. `validateAdmin`으로 호출자 관리자 여부 검증
+2. `MemberRepository`에서 Account가 없는 Slack OAuth 회원 목록 조회
+3. 각 회원 Slack ID로 DM 발송 (`SlackDmNotificationService`)
+4. 성공/실패 집계 후 `SlackSignupDmResponse` 반환
+
 ## 연관 컴포넌트
-- `member/application/dto/*` : 멤버 리스트, 단건, 부서 응답 스펙.
+- `member/application/dto/*` : 멤버 리스트, 단건, 부서, `SlackSignupDmResponse` 응답 스펙.
 - `member/application/model/*` : `ActiveStatus`, `Department`, `MemberModel`, `AdminInfo`.
+- `member/application/service/SendSignupLinkService` : Slack 전용 회원 조회 및 DM 발송 오케스트레이션.
+- `member/application/service/SlackDmNotificationService` : Slack DM 전송 인프라 어댑터.
+- `member/application/usecase/SendSignupLinkToSlackOnlyMembersUsecase` : DM 발송 유스케이스 인터페이스.
 - `member/persistence/*Repository` : JPA 저장소 어댑터(`JpaMemberRepository`, `JpaMemberCustomRepository`, `MemberRepositoryImpl`).

--- a/eeos/docs/member_README.md
+++ b/eeos/docs/member_README.md
@@ -1,9 +1,10 @@
 # Member 도메인
 
 ## 역할
-- `member/presentation/controller/MemberController`는 `/api/members`에서 활동 상태 변경, 삭제, 상태별 조회, 본인 상태 조회, 부서 변경, 부서 목록 API를 제공합니다.
+- `member/presentation/controller/MemberController`는 `/api/members`에서 활동 상태 변경, 삭제, 상태별 조회, 본인 상태 조회, 부서 변경, 부서 목록, Slack 회원가입 DM 발송 API를 제공합니다.
 - `AdminMemberService`는 관리자에 의한 활동 상태 변경/삭제(`ChangeActiveStatusUsecase`)를 담당하고, `QueryMemberService`는 상태별 조회 use case(`GetMembersByActiveStatus`, `GetMemberByActiveStatus`)를 구현합니다.
 - `DepartmentService`는 `DepartmentUsecase`를 통해 멤버의 소속 부서를 관리하며, `CreateAdminMemberService`는 애플리케이션 기동 시 최초 관리자 계정을 자동으로 생성합니다.
+- `SendSignupLinkService`는 Slack 전용 회원 전체 발송(`SendSignupLinkToSlackOnlyMembersUsecase`), 단건 발송(`SendSignupLinkToSlackOnlyMemberUsecase`), 기수별 발송(`SendSignupLinkToSlackOnlyMembersByGenerationUsecase`) 세 유스케이스를 구현합니다.
 
 ## 주요 정책
 1. **관리자 권한 검증**: `AdminMemberService.validateAdminPermission`은 작업자 ID로 `MemberRepository.findById`를 조회해 `isAdmin()`이 아니면 `DeniedMemberEditException`을 던집니다. 활동 상태 변경과 삭제 모두 같은 검증을 거칩니다.
@@ -14,6 +15,8 @@
 6. **최초 관리자 자동 생성**: `CreateAdminMemberService`의 `@PostConstruct` 로직은 DB에 관리자 멤버, 계정, OAuth 멤버가 모두 없을 때만 `AdminInfo` 설정으로 새로운 관리자/권한을 생성합니다.
 7. **네이밍 포맷**: `MemberModel.MemberModelBuilder`는 `MemberNameFormatter`를 통해 이름과 기수를 합성하는 오버로드를 제공해 동일한 네이밍 규칙을 강제합니다.
 8. **ID/존재 검증 포트**: `MemberRepository`는 `findById` 호출 시 찾지 못하면 `NotFoundMemberException`을 던지므로, 모든 서비스는 이미 존재하는 ID만 전달해야 합니다.
+9. **Slack DM 발송 대상 필터링**: `findSlackOnlyMembers` / `findSlackOnlyMembersByGeneration`은 EEOS 계정(`Account`)이 없는 Slack OAuth 회원만 반환합니다. 단건 발송(`sendSignupLink`)은 추가로 `MemberModel.isSlackOnly()` 검증을 수행하며, 통과 실패 시 `NotSlackOnlyMemberException(409)`을 던집니다.
+10. **DM 발송 실패 처리**: `SendSignupLinkService`는 개별 DM 발송 예외를 catch해 경고 로그만 남기고 계속 진행합니다. 일부 실패가 전체 요청을 중단시키지 않으며, 결과는 `successCount`/`failCount`로 집계해 반환합니다.
 
 ## 코드 컨벤션 및 구조
 - **패키지 계층**: 다른 도메인과 동일하게 `presentation/docs`, `presentation/controller`, `application/dto|model|service|usecase|support`, `persistence` 패턴을 따릅니다.
@@ -25,14 +28,9 @@
 
 ## API 명세 (추가 엔드포인트)
 
-### POST `/api/members/admin/slack-signup-dm`
+모든 엔드포인트는 JWT 인증이 필요하며 관리자 권한을 요구합니다. 요청 본문은 없습니다.
 
-Slack OAuth2로만 가입된(EEOS ID/PW 계정이 없는) 회원 전체에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다.
-
-- 인증: JWT 필수 (관리자 권한)
-- 요청 본문: 없음
-
-#### 응답
+공통 응답 스펙:
 
 ```json
 {
@@ -48,23 +46,81 @@ Slack OAuth2로만 가입된(EEOS ID/PW 계정이 없는) 회원 전체에게 EE
 | `successCount` | int | DM 발송 성공 인원 수 |
 | `failCount` | int | DM 발송 실패 인원 수 |
 
+---
+
+### POST `/api/members/admin/signup-dm`
+
+Slack OAuth2로만 가입된(EEOS ID/PW 계정이 없는) 회원 **전체**에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다.
+
 #### 오류
 
 | HTTP | 코드 | 메시지 |
 |------|------|--------|
-| 403 | 3000 | 관리자 권한이 없습니다 |
+| 403 | 3004 | 관리자 권한이 없습니다 |
 
 #### 내부 흐름
 
-1. `validateAdmin`으로 호출자 관리자 여부 검증
-2. `MemberRepository`에서 Account가 없는 Slack OAuth 회원 목록 조회
-3. 각 회원 Slack ID로 DM 발송 (`SlackDmNotificationService`)
+1. `validateAdminPermission`으로 호출자 관리자 여부 검증
+2. `MemberRepository.findSlackOnlyMembers()`로 Account가 없는 Slack OAuth 회원 목록 조회
+3. 각 회원 Slack ID로 DM 발송 (`SlackDmNotificationService.sendSignupLink`)
 4. 성공/실패 집계 후 `SlackSignupDmResponse` 반환
+
+---
+
+### POST `/api/members/admin/signup-dm/{memberId}`
+
+지정한 `memberId`의 회원이 Slack 전용 회원인 경우 해당 회원 **1인**에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다.
+
+| 파라미터 | 위치 | 타입 | 설명 |
+|---------|------|------|------|
+| `memberId` | path | Long | DM을 발송할 대상 회원 ID |
+
+#### 오류
+
+| HTTP | 코드 | 메시지 |
+|------|------|--------|
+| 403 | 3004 | 관리자 권한이 없습니다 |
+| 404 | 3000 | 존재하지 않는 멤버입니다 |
+| 409 | 4203 | Slack 전용 회원이 아닙니다 |
+
+#### 내부 흐름
+
+1. `validateAdminPermission`으로 호출자 관리자 여부 검증
+2. `MemberRepository.findById(targetMemberId)`로 대상 회원 조회 (존재하지 않으면 `NotFoundMemberException`)
+3. `MemberModel.isSlackOnly()` 검증 (EEOS 계정이 있으면 `NotSlackOnlyMemberException`)
+4. Slack DM 발송 후 성공/실패 결과 반환
+
+---
+
+### POST `/api/members/admin/signup-dm/gen/{generation}`
+
+지정한 `generation` 기수의 Slack 전용 회원 **전체**에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다.
+
+| 파라미터 | 위치 | 타입 | 설명 |
+|---------|------|------|------|
+| `generation` | path | int | 발송 대상 기수 (예: 40) |
+
+#### 오류
+
+| HTTP | 코드 | 메시지 |
+|------|------|--------|
+| 403 | 3004 | 관리자 권한이 없습니다 |
+
+#### 내부 흐름
+
+1. `validateAdminPermission`으로 호출자 관리자 여부 검증
+2. `MemberRepository.findSlackOnlyMembersByGeneration(generation)`으로 해당 기수의 Slack 전용 회원 목록 조회
+3. 각 회원 Slack ID로 DM 발송 (`SlackDmNotificationService.sendSignupLink`)
+4. 성공/실패 집계 후 `SlackSignupDmResponse` 반환
+
+---
 
 ## 연관 컴포넌트
 - `member/application/dto/*` : 멤버 리스트, 단건, 부서, `SlackSignupDmResponse` 응답 스펙.
 - `member/application/model/*` : `ActiveStatus`, `Department`, `MemberModel`, `AdminInfo`.
-- `member/application/service/SendSignupLinkService` : Slack 전용 회원 조회 및 DM 발송 오케스트레이션.
+- `member/application/service/SendSignupLinkService` : Slack 전용 회원 조회 및 DM 발송 오케스트레이션. `SendSignupLinkToSlackOnlyMembersUsecase`, `SendSignupLinkToSlackOnlyMemberUsecase`, `SendSignupLinkToSlackOnlyMembersByGenerationUsecase` 세 유스케이스를 구현합니다.
 - `member/application/service/SlackDmNotificationService` : Slack DM 전송 인프라 어댑터.
-- `member/application/usecase/SendSignupLinkToSlackOnlyMembersUsecase` : DM 발송 유스케이스 인터페이스.
+- `member/application/usecase/SendSignupLinkToSlackOnlyMembersUsecase` : 전체 발송 유스케이스 인터페이스.
+- `member/application/usecase/SendSignupLinkToSlackOnlyMemberUsecase` : 단건 발송 유스케이스 인터페이스.
+- `member/application/usecase/SendSignupLinkToSlackOnlyMembersByGenerationUsecase` : 기수별 발송 유스케이스 인터페이스.
 - `member/persistence/*Repository` : JPA 저장소 어댑터(`JpaMemberRepository`, `JpaMemberCustomRepository`, `MemberRepositoryImpl`).

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/AlreadyLinkedAccountException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/AlreadyLinkedAccountException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class AlreadyLinkedAccountException extends BusinessException {
+
+	private static final String FAIL_CODE = "4201";
+
+	public AlreadyLinkedAccountException() {
+		super(FAIL_CODE, HttpStatus.CONFLICT);
+	}
+
+	@Override
+	public String getMessage() {
+		return "이미 계정이 연결된 회원입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidSignupCodeException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/InvalidSignupCodeException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidSignupCodeException extends BusinessException {
+
+	private static final String FAIL_CODE = "4202";
+
+	public InvalidSignupCodeException() {
+		super(FAIL_CODE, HttpStatus.BAD_REQUEST);
+	}
+
+	@Override
+	public String getMessage() {
+		return "유효하지 않은 가입 코드입니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/SlackMemberNotFoundException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/exception/SlackMemberNotFoundException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.auth.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class SlackMemberNotFoundException extends BusinessException {
+
+	private static final String FAIL_CODE = "4200";
+
+	public SlackMemberNotFoundException() {
+		super(FAIL_CODE, HttpStatus.NOT_FOUND);
+	}
+
+	@Override
+	public String getMessage() {
+		return "해당 Slack 회원을 찾을 수 없습니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/repository/AccountRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/repository/AccountRepository.java
@@ -9,4 +9,6 @@ public interface AccountRepository {
 	AccountModel save(AccountModel model);
 
 	boolean existsByLoginId(String loginId);
+
+	boolean existsByMemberId(Long memberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/repository/OAuthMemberRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/repository/OAuthMemberRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 public interface OAuthMemberRepository {
 	Optional<OauthMemberModel> findByOauthId(String oauthId);
 
+	Optional<OauthMemberModel> findByMemberId(Long memberId);
+
 	Optional<OAuthMemberEntity> findByAccount(String loginId);
 
 	OauthMemberModel save(OauthMemberModel model);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -1,7 +1,7 @@
 package com.blackcompany.eeos.auth.application.service;
 
-import com.blackcompany.eeos.auth.application.domain.OauthServerType;
 import com.blackcompany.eeos.auth.application.domain.OauthMemberModel;
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
 import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
 import com.blackcompany.eeos.auth.application.exception.AlreadyLinkedAccountException;

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -15,6 +15,7 @@ import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
 import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
 import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
+import com.blackcompany.eeos.auth.application.support.SlackSignupCodeEncoder;
 import com.blackcompany.eeos.auth.application.usecase.EeosSignUpUseCase;
 import com.blackcompany.eeos.member.application.model.ActiveStatus;
 import com.blackcompany.eeos.member.application.model.MemberModel;
@@ -38,6 +39,7 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 	private final OAuthMemberRepository oAuthMemberRepository;
 	private final EncryptHelper encryptHelper;
 	private final AuthenticationTokenGenerator tokenGenerator;
+	private final SlackSignupCodeEncoder slackSignupCodeEncoder;
 
 	@Override
 	@Transactional
@@ -51,13 +53,12 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 
 	@Override
 	@Transactional
-	public TokenModel signUp(EeosSignUpCommand command, String slackMemberId) {
+	public TokenModel signUp(EeosSignUpCommand command, String code) {
 		validateDuplicateLoginId(command.getLoginId());
 
+		String oauthId = slackSignupCodeEncoder.decode(code);
 		OauthMemberModel oauthMember =
-				oAuthMemberRepository
-						.findByOauthId(slackMemberId)
-						.orElseThrow(SlackMemberNotFoundException::new);
+				oAuthMemberRepository.findByOauthId(oauthId).orElseThrow(SlackMemberNotFoundException::new);
 		Long memberId = oauthMember.getMemberId();
 		if (accountRepository.existsByMemberId(memberId)) {
 			throw new AlreadyLinkedAccountException();

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -64,7 +64,8 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 			throw new AlreadyLinkedAccountException();
 		}
 
-		return signUpWithExistingMember(command, memberId);
+		saveAccount(command.getLoginId(), command.getPassword(), memberId);
+		return tokenGenerator.execute(memberId, Set.of(Role.ROLE_USER.name()));
 	}
 
 	private void validateDuplicateLoginId(String loginId) {

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -94,8 +94,18 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 		try {
 			accountRepository.save(accountModel);
 		} catch (DataIntegrityViolationException e) {
-			log.warn("loginId 중복 저장 시도 발생");
-			throw new DuplicateLoginIdException();
+
+			String cause = e.getMostSpecificCause().getMessage();
+
+			if (cause != null && cause.contains("account_login_id")) {
+				log.warn("loginId 중복 저장 시도 발생");
+				throw new DuplicateLoginIdException();
+			}
+
+			throw e;
+		} catch (Exception e) {
+			log.error("회원가입 실패", e);
+			throw e;
 		}
 	}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/service/EeosSignUpService.java
@@ -1,14 +1,18 @@
 package com.blackcompany.eeos.auth.application.service;
 
 import com.blackcompany.eeos.auth.application.domain.OauthServerType;
+import com.blackcompany.eeos.auth.application.domain.OauthMemberModel;
 import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+import com.blackcompany.eeos.auth.application.exception.AlreadyLinkedAccountException;
 import com.blackcompany.eeos.auth.application.exception.DuplicateLoginIdException;
+import com.blackcompany.eeos.auth.application.exception.SlackMemberNotFoundException;
 import com.blackcompany.eeos.auth.application.model.AccountModel;
 import com.blackcompany.eeos.auth.application.model.AuthorityModel;
 import com.blackcompany.eeos.auth.application.model.Role;
 import com.blackcompany.eeos.auth.application.repository.AccountRepository;
 import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
+import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
 import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
 import com.blackcompany.eeos.auth.application.usecase.EeosSignUpUseCase;
@@ -31,6 +35,7 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 	private final MemberRepository memberRepository;
 	private final AccountRepository accountRepository;
 	private final AuthorityRepository authorityRepository;
+	private final OAuthMemberRepository oAuthMemberRepository;
 	private final EncryptHelper encryptHelper;
 	private final AuthenticationTokenGenerator tokenGenerator;
 
@@ -41,10 +46,24 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 
 		MemberModel savedMember =
 				saveMember(command.getName(), command.getGeneration(), command.getActiveStatus());
-		saveAccount(command.getLoginId(), command.getPassword(), savedMember.getMemberId());
-		saveAuthority(savedMember.getMemberId());
+		return signUpWithExistingMember(command, savedMember.getMemberId());
+	}
 
-		return tokenGenerator.execute(savedMember.getMemberId(), Set.of(Role.ROLE_USER.name()));
+	@Override
+	@Transactional
+	public TokenModel signUp(EeosSignUpCommand command, String slackMemberId) {
+		validateDuplicateLoginId(command.getLoginId());
+
+		OauthMemberModel oauthMember =
+				oAuthMemberRepository
+						.findByOauthId(slackMemberId)
+						.orElseThrow(SlackMemberNotFoundException::new);
+		Long memberId = oauthMember.getMemberId();
+		if (accountRepository.existsByMemberId(memberId)) {
+			throw new AlreadyLinkedAccountException();
+		}
+
+		return signUpWithExistingMember(command, memberId);
 	}
 
 	private void validateDuplicateLoginId(String loginId) {
@@ -81,5 +100,11 @@ public class EeosSignUpService implements EeosSignUpUseCase {
 
 	private void saveAuthority(Long memberId) {
 		authorityRepository.save(AuthorityModel.create(memberId, Role.ROLE_USER));
+	}
+
+	private TokenModel signUpWithExistingMember(EeosSignUpCommand command, Long memberId) {
+		saveAccount(command.getLoginId(), command.getPassword(), memberId);
+		saveAuthority(memberId);
+		return tokenGenerator.execute(memberId, Set.of(Role.ROLE_USER.name()));
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/SlackSignupCodeEncoder.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/SlackSignupCodeEncoder.java
@@ -1,0 +1,72 @@
+package com.blackcompany.eeos.auth.application.support;
+
+import com.blackcompany.eeos.auth.application.exception.InvalidSignupCodeException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SlackSignupCodeEncoder {
+
+	private static final String ALGORITHM = "AES/GCM/NoPadding";
+	private static final int GCM_IV_LENGTH = 12;
+	private static final int GCM_TAG_LENGTH = 128;
+
+	private final SecretKeySpec secretKey;
+
+	public SlackSignupCodeEncoder(@Value("${eeos.signup.code-secret}") String secret) {
+		byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+		if (keyBytes.length != 16 && keyBytes.length != 24 && keyBytes.length != 32) {
+			throw new IllegalArgumentException(
+					"eeos.slack.signup.code-secret must be 16, 24, or 32 bytes");
+		}
+		this.secretKey = new SecretKeySpec(keyBytes, "AES");
+	}
+
+	public String encode(String oauthId) {
+		try {
+			// 초기화 벡터
+			byte[] iv = new byte[GCM_IV_LENGTH];
+			new SecureRandom().nextBytes(iv);
+
+			Cipher cipher = Cipher.getInstance(ALGORITHM);
+			cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+			byte[] encrypted = cipher.doFinal(oauthId.getBytes(StandardCharsets.UTF_8));
+
+			ByteBuffer buffer = ByteBuffer.allocate(iv.length + encrypted.length);
+			buffer.put(iv);
+			buffer.put(encrypted);
+
+			return Base64.getUrlEncoder().withoutPadding().encodeToString(buffer.array());
+		} catch (Exception e) {
+			throw new RuntimeException("Slack signup code 암호화 실패", e);
+		}
+	}
+
+	public String decode(String code) {
+		try {
+			byte[] decoded = Base64.getUrlDecoder().decode(code);
+			ByteBuffer buffer = ByteBuffer.wrap(decoded);
+
+			byte[] iv = new byte[GCM_IV_LENGTH];
+			buffer.get(iv);
+
+			byte[] encrypted = new byte[buffer.remaining()];
+			buffer.get(encrypted);
+
+			Cipher cipher = Cipher.getInstance(ALGORITHM);
+			cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+			return new String(cipher.doFinal(encrypted), java.nio.charset.StandardCharsets.UTF_8);
+		} catch (Exception e) {
+			throw new InvalidSignupCodeException();
+		}
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/SlackSignupCodeEncoder.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/support/SlackSignupCodeEncoder.java
@@ -23,8 +23,7 @@ public class SlackSignupCodeEncoder {
 	public SlackSignupCodeEncoder(@Value("${eeos.signup.code-secret}") String secret) {
 		byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
 		if (keyBytes.length != 16 && keyBytes.length != 24 && keyBytes.length != 32) {
-			throw new IllegalArgumentException(
-					"eeos.slack.signup.code-secret must be 16, 24, or 32 bytes");
+			throw new IllegalArgumentException("암호화 시크릿 키 length 오류 (16/24/32 바이트 중 하나)");
 		}
 		this.secretKey = new SecretKeySpec(keyBytes, "AES");
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/application/usecase/EeosSignUpUseCase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/application/usecase/EeosSignUpUseCase.java
@@ -5,4 +5,6 @@ import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
 
 public interface EeosSignUpUseCase {
 	TokenModel signUp(EeosSignUpCommand command);
+
+	TokenModel signUp(EeosSignUpCommand command, String slackMemberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountJpaRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountJpaRepository.java
@@ -14,4 +14,6 @@ public interface AccountJpaRepository extends JpaRepository<AccountEntity, Long>
 	Optional<AccountEntity> findByLoginId(@Param("loginId") String loginId);
 
 	boolean existsByLoginId(String loginId);
+
+	boolean existsByMemberId(Long memberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/account/AccountRepositoryImpl.java
@@ -36,4 +36,9 @@ public class AccountRepositoryImpl implements AccountRepository {
 	public boolean existsByLoginId(String loginId) {
 		return jpaRepository.existsByLoginId(loginId);
 	}
+
+	@Override
+	public boolean existsByMemberId(Long memberId) {
+		return jpaRepository.existsByMemberId(memberId);
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/oauth/OAuthMemberRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/persistence/oauth/OAuthMemberRepositoryImpl.java
@@ -19,6 +19,11 @@ public class OAuthMemberRepositoryImpl implements OAuthMemberRepository {
 	}
 
 	@Override
+	public Optional<OauthMemberModel> findByMemberId(Long memberId) {
+		return jpaRepository.findByMemberId(memberId).map(converter::from);
+	}
+
+	@Override
 	public Optional<OAuthMemberEntity> findByAccount(String loginId) {
 		return jpaRepository.findByAccount(loginId);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -6,7 +6,12 @@ import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConvert
 import com.blackcompany.eeos.auth.application.dto.request.AdditionalInfoApplicationCommand;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
-import com.blackcompany.eeos.auth.application.usecase.*;
+import com.blackcompany.eeos.auth.application.usecase.EeosSignUpUseCase;
+import com.blackcompany.eeos.auth.application.usecase.LogOutUsecase;
+import com.blackcompany.eeos.auth.application.usecase.LoginUsecase;
+import com.blackcompany.eeos.auth.application.usecase.OAuthSignUpUseCase;
+import com.blackcompany.eeos.auth.application.usecase.ReissueUsecase;
+import com.blackcompany.eeos.auth.application.usecase.WithDrawUsecase;
 import com.blackcompany.eeos.auth.presentation.docs.AuthApi;
 import com.blackcompany.eeos.auth.presentation.dto.AdditionalInfoRequest;
 import com.blackcompany.eeos.auth.presentation.dto.EeosSignUpRequest;
@@ -23,6 +28,7 @@ import com.blackcompany.eeos.common.presentation.support.CookieManager;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
@@ -130,7 +136,12 @@ public class AuthController implements AuthApi {
 						request.getGeneration(),
 						request.getName(),
 						request.getActiveStatus());
-		TokenModel tokenModel = eeosSignUpUseCase.signUp(command);
+
+		TokenModel tokenModel =
+				Optional.ofNullable(request.getSlackMemberId())
+						.map(id -> eeosSignUpUseCase.signUp(command, id))
+						.orElseGet(() -> eeosSignUpUseCase.signUp(command));
+
 		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
 		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -37,6 +37,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -128,7 +129,9 @@ public class AuthController implements AuthApi {
 	@Override
 	@PostMapping("/signup")
 	public ApiResponse<SuccessBody<TokenResponse>> signUp(
-			@Valid @RequestBody EeosSignUpRequest request, HttpServletResponse httpResponse) {
+			@Valid @RequestBody EeosSignUpRequest request,
+			@RequestParam(required = false) String code,
+			HttpServletResponse httpResponse) {
 		EeosSignUpCommand command =
 				new EeosSignUpCommand(
 						request.getId(),
@@ -138,8 +141,8 @@ public class AuthController implements AuthApi {
 						request.getActiveStatus());
 
 		TokenModel tokenModel =
-				Optional.ofNullable(request.getSlackMemberId())
-						.map(id -> eeosSignUpUseCase.signUp(command, id))
+				Optional.ofNullable(code)
+						.map(c -> eeosSignUpUseCase.signUp(command, c))
 						.orElseGet(() -> eeosSignUpUseCase.signUp(command));
 
 		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -23,8 +23,8 @@ public interface AuthApi {
 			summary = "회원가입",
 			description =
 					"id, password, 기수, 성함, 활동상태로 회원가입하고 토큰을 반환한다.\n\n"
-							+ "`slackMemberId`를 함께 전달하면 기존 Slack OAuth 회원에 EEOS 계정을 연결하는 방식으로 가입한다."
-							+ " `slackMemberId`가 없으면 새 회원을 생성하는 기존 로직을 따른다.")
+							+ "쿼리 파라미터 `code`를 함께 전달하면 기존 Slack OAuth 회원에 EEOS 계정을 연결하는 방식으로 가입한다."
+							+ " `code`가 없으면 새 회원을 생성하는 기존 로직을 따른다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "201",

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -18,7 +18,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "인증", description = "인증 관련 API")
 public interface AuthApi {
-	@Operation(summary = "회원가입", description = "id, password, 기수, 성함, 활동상태로 회원가입하고 토큰을 반환한다.")
+	@Operation(
+			summary = "회원가입",
+			description =
+					"id, password, 기수, 성함, 활동상태로 회원가입하고 토큰을 반환한다.\n\n"
+							+ "`slackMemberId`를 함께 전달하면 기존 Slack OAuth 회원에 EEOS 계정을 연결하는 방식으로 가입한다."
+							+ " `slackMemberId`가 없으면 새 회원을 생성하는 기존 로직을 따른다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "201",
@@ -42,8 +47,16 @@ public interface AuthApi {
 								+ "| 3001 | {status}는 존재하지 않는 활동 상태입니다 |",
 				content = @Content),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "404",
+				description = "4200: 존재하지 않는 Slack 회원 ID입니다",
+				content = @Content),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "409",
-				description = "4009: 이미 사용 중인 아이디입니다",
+				description =
+						"| 코드 | 메시지 |\n"
+								+ "|------|--------|\n"
+								+ "| 4009 | 이미 사용 중인 아이디입니다 |\n"
+								+ "| 4201 | 이미 계정이 연결된 회원입니다 |",
 				content = @Content)
 	})
 	ApiResponse<SuccessBody<TokenResponse>> signUp(

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "인증", description = "인증 관련 API")
 public interface AuthApi {
@@ -62,6 +63,11 @@ public interface AuthApi {
 	ApiResponse<SuccessBody<TokenResponse>> signUp(
 			@Parameter(description = "회원가입 요청 정보", required = true) @Valid @RequestBody
 					EeosSignUpRequest request,
+			@Parameter(
+							description = "Slack 연동 가입 코드. Slack DM으로 전달된 링크의 ?code= 값. 일반 신규 가입 시 생략.",
+							required = false)
+					@RequestParam(required = false)
+					String code,
 			HttpServletResponse httpResponse);
 
 	@Operation(

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
@@ -6,29 +6,37 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 public class EeosSignUpRequest {
 
+	@Schema(
+			description = "로그인 아이디",
+			example = "econovation2025",
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "4100:아이디는 필수 입력값입니다")
 	@Size(max = 50, message = "4101:아이디는 50자 이하여야 합니다")
 	private String id;
 
+	@Schema(
+			description = "비밀번호 (영문+숫자 조합 8~20자)",
+			example = "eeos1234",
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "4102:비밀번호는 필수 입력값입니다")
 	@Pattern(
 			regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
 			message = "4103:비밀번호는 8~20자이며, 영문과 숫자를 포함해야 합니다")
 	private String password;
 
+	@Schema(description = "에코노베이션 기수", example = "30", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "4104:기수는 필수 입력값입니다")
 	@Min(value = 1, message = "4105:기수는 1 이상이어야 합니다")
 	private Integer generation;
 
+	@Schema(description = "회원 성함", example = "김에코", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "4106:성함은 필수 입력값입니다")
 	@Size(max = 50, message = "4107:성함은 50자 이하여야 합니다")
 	private String name;
@@ -38,6 +46,37 @@ public class EeosSignUpRequest {
 	@Schema(
 			description = "활동 상태",
 			example = "am",
-			allowableValues = {"am", "cm", "rm", "ob"})
+			allowableValues = {"am", "cm", "rm", "ob"},
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	private String activeStatus;
+
+	@Schema(
+			description = "Slack 회원 ID. Slack OAuth2로만 가입된 회원이 EEOS 계정을 연결할 때 사용합니다. 일반 신규 가입 시에는 생략합니다.",
+			example = "U08ABCDE123",
+			nullable = true)
+	private String slackMemberId;
+
+	public EeosSignUpRequest(
+			String id, String password, Integer generation, String name, String activeStatus) {
+		this.id = id;
+		this.password = password;
+		this.generation = generation;
+		this.name = name;
+		this.activeStatus = activeStatus;
+	}
+
+	public EeosSignUpRequest(
+			String id,
+			String password,
+			Integer generation,
+			String name,
+			String activeStatus,
+			String slackMemberId) {
+		this.id = id;
+		this.password = password;
+		this.generation = generation;
+		this.name = name;
+		this.activeStatus = activeStatus;
+		this.slackMemberId = slackMemberId;
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
@@ -50,12 +50,6 @@ public class EeosSignUpRequest {
 			requiredMode = Schema.RequiredMode.REQUIRED)
 	private String activeStatus;
 
-	@Schema(
-			description = "Slack 회원 ID. Slack OAuth2로만 가입된 회원이 EEOS 계정을 연결할 때 사용합니다. 일반 신규 가입 시에는 생략합니다.",
-			example = "U08ABCDE123",
-			nullable = true)
-	private String slackMemberId;
-
 	public EeosSignUpRequest(
 			String id, String password, Integer generation, String name, String activeStatus) {
 		this.id = id;
@@ -63,20 +57,5 @@ public class EeosSignUpRequest {
 		this.generation = generation;
 		this.name = name;
 		this.activeStatus = activeStatus;
-	}
-
-	public EeosSignUpRequest(
-			String id,
-			String password,
-			Integer generation,
-			String name,
-			String activeStatus,
-			String slackMemberId) {
-		this.id = id;
-		this.password = password;
-		this.generation = generation;
-		this.name = name;
-		this.activeStatus = activeStatus;
-		this.slackMemberId = slackMemberId;
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/dto/SlackSignupDmResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/dto/SlackSignupDmResponse.java
@@ -1,0 +1,23 @@
+package com.blackcompany.eeos.member.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SlackSignupDmResponse {
+
+	@Schema(description = "DM 발송 대상 총 인원 수", example = "12")
+	private int totalCount;
+
+	@Schema(description = "DM 발송 성공 인원 수", example = "11")
+	private int successCount;
+
+	@Schema(description = "DM 발송 실패 인원 수", example = "1")
+	private int failCount;
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/exception/NotSlackOnlyMemberException.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/exception/NotSlackOnlyMemberException.java
@@ -1,0 +1,18 @@
+package com.blackcompany.eeos.member.application.exception;
+
+import com.blackcompany.eeos.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+/** 대상 회원이 Slack 전용 회원이 아닐 때 발생하는 예외 */
+public class NotSlackOnlyMemberException extends BusinessException {
+	private static final String FAIL_CODE = "4203";
+
+	public NotSlackOnlyMemberException() {
+		super(FAIL_CODE, HttpStatus.CONFLICT);
+	}
+
+	@Override
+	public String getMessage() {
+		return "Slack 전용 회원이 아닙니다.";
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/model/MemberModel.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/model/MemberModel.java
@@ -36,6 +36,10 @@ public class MemberModel implements AbstractModel, MemberIdModel {
 		return this;
 	}
 
+	public boolean isSlackOnly() {
+		return OauthServerType.SLACK.equals(oauthServerType);
+	}
+
 	// TODO : Equals 재정의로 고민
 	public boolean validateSame(Long memberId) {
 		return id.equals(memberId);

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/repository/MemberRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/repository/MemberRepository.java
@@ -30,4 +30,6 @@ public interface MemberRepository {
 	String findNameById(Long memberId);
 
 	List<MemberModel> findSlackOnlyMembers();
+
+	List<MemberModel> findSlackOnlyMembersByGeneration(int generation);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/repository/MemberRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/repository/MemberRepository.java
@@ -28,4 +28,6 @@ public interface MemberRepository {
 	void deleteById(Long memberId);
 
 	String findNameById(Long memberId);
+
+	List<MemberModel> findSlackOnlyMembers();
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
@@ -2,8 +2,10 @@ package com.blackcompany.eeos.member.application.service;
 
 import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
 import com.blackcompany.eeos.member.application.exception.DeniedMemberEditException;
+import com.blackcompany.eeos.member.application.exception.NotSlackOnlyMemberException;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMemberUsecase;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +14,8 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class SendSignupLinkService implements SendSignupLinkToSlackOnlyMembersUsecase {
+public class SendSignupLinkService
+		implements SendSignupLinkToSlackOnlyMembersUsecase, SendSignupLinkToSlackOnlyMemberUsecase {
 
 	private final MemberRepository memberRepository;
 	private final SlackDmNotificationService slackDmNotificationService;
@@ -56,6 +59,27 @@ public class SendSignupLinkService implements SendSignupLinkToSlackOnlyMembersUs
 				.successCount(successCount)
 				.failCount(failCount)
 				.build();
+	}
+
+	@Override
+	public SlackSignupDmResponse sendSignupLink(Long adminMemberId, Long targetMemberId) {
+		validateAdminPermission(adminMemberId);
+		MemberModel target = memberRepository.findById(targetMemberId);
+		if (!target.isSlackOnly()) {
+			throw new NotSlackOnlyMemberException();
+		}
+		try {
+			slackDmNotificationService.sendSignupLink(target, signupUrl);
+			return SlackSignupDmResponse.builder().totalCount(1).successCount(1).failCount(0).build();
+		} catch (Exception e) {
+			log.warn(
+					"Slack DM 발송 실패. memberId={}, memberName={}, error={}",
+					target.getId(),
+					target.getName(),
+					e.getMessage(),
+					e);
+			return SlackSignupDmResponse.builder().totalCount(1).successCount(0).failCount(1).build();
+		}
 	}
 
 	private void validateAdminPermission(Long memberId) {

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
@@ -6,25 +6,24 @@ import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class SendSignupLinkService implements SendSignupLinkToSlackOnlyMembersUsecase {
 
 	private final MemberRepository memberRepository;
 	private final SlackDmNotificationService slackDmNotificationService;
+	private final String signupUrl;
 
-	private String signupUrl = "https://eeos.econovation.kr/signup";
-
-	@Value("${eeos.signup.url:https://eeos.econovation.kr/signup}")
-	public void setSignupUrl(String signupUrl) {
+	public SendSignupLinkService(
+			MemberRepository memberRepository,
+			SlackDmNotificationService slackDmNotificationService,
+			@Value("${eeos.signup.url:https://auth.econovation.kr}") String signupUrl) {
+		this.memberRepository = memberRepository;
+		this.slackDmNotificationService = slackDmNotificationService;
 		this.signupUrl = signupUrl;
 	}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
@@ -1,0 +1,68 @@
+package com.blackcompany.eeos.member.application.service;
+
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+import com.blackcompany.eeos.member.application.exception.DeniedMemberEditException;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SendSignupLinkService implements SendSignupLinkToSlackOnlyMembersUsecase {
+
+	private final MemberRepository memberRepository;
+	private final SlackDmNotificationService slackDmNotificationService;
+
+	private String signupUrl = "https://eeos.econovation.kr/signup";
+
+	@Value("${eeos.signup.url:https://eeos.econovation.kr/signup}")
+	public void setSignupUrl(String signupUrl) {
+		this.signupUrl = signupUrl;
+	}
+
+	@Override
+	public SlackSignupDmResponse sendSignupLinks(Long adminMemberId) {
+		validateAdminPermission(adminMemberId);
+		List<MemberModel> targets = memberRepository.findSlackOnlyMembers();
+
+		int totalCount = targets.size();
+		int successCount = 0;
+		int failCount = 0;
+
+		for (MemberModel member : targets) {
+			try {
+				slackDmNotificationService.sendSignupLink(member, signupUrl);
+				successCount++;
+			} catch (Exception e) {
+				log.warn(
+						"Slack DM 발송 실패. memberId={}, memberName={}, error={}",
+						member.getId(),
+						member.getName(),
+						e.getMessage(),
+						e);
+				failCount++;
+			}
+		}
+
+		return SlackSignupDmResponse.builder()
+				.totalCount(totalCount)
+				.successCount(successCount)
+				.failCount(failCount)
+				.build();
+	}
+
+	private void validateAdminPermission(Long memberId) {
+		MemberModel member = memberRepository.findById(memberId);
+		if (!member.isAdmin()) {
+			throw new DeniedMemberEditException(memberId);
+		}
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SendSignupLinkService.java
@@ -6,6 +6,7 @@ import com.blackcompany.eeos.member.application.exception.NotSlackOnlyMemberExce
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMemberUsecase;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersByGenerationUsecase;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +16,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 public class SendSignupLinkService
-		implements SendSignupLinkToSlackOnlyMembersUsecase, SendSignupLinkToSlackOnlyMemberUsecase {
+		implements SendSignupLinkToSlackOnlyMembersUsecase,
+				SendSignupLinkToSlackOnlyMemberUsecase,
+				SendSignupLinkToSlackOnlyMembersByGenerationUsecase {
 
 	private final MemberRepository memberRepository;
 	private final SlackDmNotificationService slackDmNotificationService;
@@ -80,6 +83,37 @@ public class SendSignupLinkService
 					e);
 			return SlackSignupDmResponse.builder().totalCount(1).successCount(0).failCount(1).build();
 		}
+	}
+
+	@Override
+	public SlackSignupDmResponse sendSignupLinksByGeneration(Long adminMemberId, int generation) {
+		validateAdminPermission(adminMemberId);
+		List<MemberModel> targets = memberRepository.findSlackOnlyMembersByGeneration(generation);
+
+		int totalCount = targets.size();
+		int successCount = 0;
+		int failCount = 0;
+
+		for (MemberModel member : targets) {
+			try {
+				slackDmNotificationService.sendSignupLink(member, signupUrl);
+				successCount++;
+			} catch (Exception e) {
+				log.warn(
+						"Slack DM 발송 실패. memberId={}, memberName={}, error={}",
+						member.getId(),
+						member.getName(),
+						e.getMessage(),
+						e);
+				failCount++;
+			}
+		}
+
+		return SlackSignupDmResponse.builder()
+				.totalCount(totalCount)
+				.successCount(successCount)
+				.failCount(failCount)
+				.build();
 	}
 
 	private void validateAdminPermission(Long memberId) {

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SlackDmNotificationService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SlackDmNotificationService.java
@@ -2,6 +2,7 @@ package com.blackcompany.eeos.member.application.service;
 
 import com.blackcompany.eeos.auth.application.exception.SlackMemberNotFoundException;
 import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
+import com.blackcompany.eeos.auth.application.support.SlackSignupCodeEncoder;
 import com.blackcompany.eeos.auth.infra.oauth.slack.exception.SlackApiException;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.program.infra.api.slack.chat.client.SlackChatApiClient;
@@ -25,12 +26,15 @@ public class SlackDmNotificationService {
 	private final SlackChatApiClient slackChatApiClient;
 	private final ObjectMapper objectMapper;
 	private final OAuthMemberRepository oAuthMemberRepository;
+	private final SlackSignupCodeEncoder slackSignupCodeEncoder;
 
 	@Value("${slack.bot.dm.token}")
 	private String dmBotToken;
 
 	public void sendSignupLink(MemberModel member, String signupUrl) {
 		String oauthId = resolveOauthId(member);
+		String code = slackSignupCodeEncoder.encode(oauthId);
+		String separator = signupUrl.contains("?") ? "&" : "?";
 		String message =
 				String.format(
 						"*EEOS 회원가입 안내*\n\n"
@@ -38,7 +42,7 @@ public class SlackDmNotificationService {
 								+ "EEOS가 새롭게 돌아왔습니다!\n\n"
 								+ "아래 링크를 통해 EEOS 계정을 등록해 주세요.\n\n"
 								+ "가입 링크: %s",
-						member.getName(), String.format("%s?slackUserId=%s", signupUrl, oauthId));
+						member.getName(), String.format("%s%scode=%s", signupUrl, separator, code));
 
 		String blocks = buildBlocks(message);
 		try {

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SlackDmNotificationService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SlackDmNotificationService.java
@@ -1,0 +1,133 @@
+package com.blackcompany.eeos.member.application.service;
+
+import com.blackcompany.eeos.auth.application.exception.SlackMemberNotFoundException;
+import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
+import com.blackcompany.eeos.auth.infra.oauth.slack.exception.SlackApiException;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.program.infra.api.slack.chat.client.SlackChatApiClient;
+import com.blackcompany.eeos.program.infra.api.slack.chat.dto.SlackChatPostMessageResponse;
+import com.blackcompany.eeos.program.infra.api.slack.chat.dto.SlackConversationOpenResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackDmNotificationService {
+
+	private final SlackChatApiClient slackChatApiClient;
+	private final ObjectMapper objectMapper;
+	private final OAuthMemberRepository oAuthMemberRepository;
+
+	@Value("${slack.bot.dm.token}")
+	private String dmBotToken;
+
+	public void sendSignupLink(MemberModel member, String signupUrl) {
+		String oauthId = resolveOauthId(member);
+		String message =
+				String.format(
+						"*EEOS 회원가입 안내*\n\n"
+								+ "안녕하세요, %s님!\n\n"
+								+ "EEOS가 새롭게 돌아왔습니다!\n\n"
+								+ "아래 링크를 통해 EEOS 계정을 등록해 주세요.\n\n"
+								+ "가입 링크: %s",
+						member.getName(), String.format("%s?slackUserId=%s", signupUrl, oauthId));
+
+		String blocks = buildBlocks(message);
+		try {
+			SlackConversationOpenResponse openResponse =
+					slackChatApiClient.openConversation("Bearer " + dmBotToken, oauthId);
+
+			if (openResponse == null) {
+				log.error(
+						"Slack conversations.open 응답이 비어있습니다. memberId={}, oauthId={}",
+						member.getId(),
+						oauthId);
+				throw new RuntimeException("Slack conversations.open 응답이 비어있습니다.");
+			}
+
+			if (!openResponse.isOk()) {
+				log.error(
+						"Slack conversations.open 실패 응답. memberId={}, oauthId={}, error={}",
+						member.getId(),
+						oauthId,
+						openResponse.getError());
+				throw new SlackApiException("conversations.open", openResponse);
+			}
+
+			String dmChannelId = openResponse.getChannelId();
+			if (dmChannelId == null || dmChannelId.isBlank()) {
+				log.error(
+						"Slack DM 채널 ID가 비어있습니다. memberId={}, oauthId={}",
+						member.getId(),
+						oauthId);
+				throw new RuntimeException("Slack DM 채널 ID가 비어있습니다.");
+			}
+
+			SlackChatPostMessageResponse response =
+					slackChatApiClient.post("Bearer " + dmBotToken, dmChannelId, blocks, "EEOS Bot");
+
+			if (response == null) {
+				log.error(
+						"Slack DM 응답이 비어있습니다. memberId={}, oauthId={}, dmChannelId={}",
+						member.getId(),
+						oauthId,
+						dmChannelId);
+				throw new RuntimeException("Slack DM 응답이 비어있습니다.");
+			}
+
+			if (!response.isOk()) {
+				log.error(
+						"Slack DM 발송 실패 응답. memberId={}, oauthId={}, dmChannelId={}, error={}, channel={}, ts={}",
+						member.getId(),
+						oauthId,
+						dmChannelId,
+						response.getError(),
+						response.getChannel(),
+						response.getTimestamp());
+				throw new SlackApiException("chat.postMessage", response);
+			}
+
+			log.info(
+					"Slack DM 발송 성공. memberId={}, oauthId={}, dmChannelId={}, channel={}, ts={}",
+					member.getId(),
+					oauthId,
+					dmChannelId,
+					response.getChannel(),
+					response.getTimestamp());
+		} catch (FeignException e) {
+			log.error(
+					"Slack API 호출 예외. memberId={}, oauthId={}, status={}, responseBody={}",
+					member.getId(),
+					oauthId,
+					e.status(),
+					e.contentUTF8(),
+					e);
+			throw e;
+		}
+	}
+
+	private String resolveOauthId(MemberModel member) {
+		return oAuthMemberRepository
+				.findByMemberId(member.getId())
+				.map(oauthMember -> oauthMember.getOauthId())
+				.orElseThrow(SlackMemberNotFoundException::new);
+	}
+
+	private String buildBlocks(String text) {
+		try {
+			return objectMapper.writeValueAsString(
+					List.of(Map.of("type", "section", "text", Map.of("type", "mrkdwn", "text", text))));
+		} catch (JsonProcessingException e) {
+			log.error("Slack 메시지 블록 직렬화 실패", e);
+			throw new RuntimeException("Slack 메시지 블록 생성 실패", e);
+		}
+	}
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SlackDmNotificationService.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/service/SlackDmNotificationService.java
@@ -64,10 +64,7 @@ public class SlackDmNotificationService {
 
 			String dmChannelId = openResponse.getChannelId();
 			if (dmChannelId == null || dmChannelId.isBlank()) {
-				log.error(
-						"Slack DM 채널 ID가 비어있습니다. memberId={}, oauthId={}",
-						member.getId(),
-						oauthId);
+				log.error("Slack DM 채널 ID가 비어있습니다. memberId={}, oauthId={}", member.getId(), oauthId);
 				throw new RuntimeException("Slack DM 채널 ID가 비어있습니다.");
 			}
 

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/usecase/SendSignupLinkToSlackOnlyMemberUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/usecase/SendSignupLinkToSlackOnlyMemberUsecase.java
@@ -1,0 +1,7 @@
+package com.blackcompany.eeos.member.application.usecase;
+
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+
+public interface SendSignupLinkToSlackOnlyMemberUsecase {
+	SlackSignupDmResponse sendSignupLink(Long adminMemberId, Long targetMemberId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/usecase/SendSignupLinkToSlackOnlyMembersByGenerationUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/usecase/SendSignupLinkToSlackOnlyMembersByGenerationUsecase.java
@@ -1,0 +1,7 @@
+package com.blackcompany.eeos.member.application.usecase;
+
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+
+public interface SendSignupLinkToSlackOnlyMembersByGenerationUsecase {
+	SlackSignupDmResponse sendSignupLinksByGeneration(Long adminMemberId, int generation);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/application/usecase/SendSignupLinkToSlackOnlyMembersUsecase.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/application/usecase/SendSignupLinkToSlackOnlyMembersUsecase.java
@@ -1,0 +1,7 @@
+package com.blackcompany.eeos.member.application.usecase;
+
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+
+public interface SendSignupLinkToSlackOnlyMembersUsecase {
+	SlackSignupDmResponse sendSignupLinks(Long adminMemberId);
+}

--- a/eeos/src/main/java/com/blackcompany/eeos/member/persistence/JpaMemberRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/persistence/JpaMemberRepository.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.member.persistence;
 
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
 import com.blackcompany.eeos.member.application.model.ActiveStatus;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +26,12 @@ public interface JpaMemberRepository extends JpaRepository<MemberEntity, Long> {
 
 	@Query("SELECT m.name FROM MemberEntity  m WHERE m.id=:id AND m.isDeleted=false")
 	Optional<String> findNameById(@Param("id") Long id);
+
+	@Query(
+			"SELECT m FROM MemberEntity m WHERE m.oauthServerType = :oauthServerType AND m.isDeleted=false"
+					+ " AND m.id NOT IN (SELECT a.memberId FROM AccountEntity a WHERE a.isDeleted=false)")
+	List<MemberEntity> findSlackOnlyMembers(
+			@Param("oauthServerType") OauthServerType oauthServerType);
 
 	// 동작하지 않는 쿼리 : SQL 의 FILED 함수 내에 List<Long> 이 들어갈 때, 단일 파라미터로 들어가기 때문에 CustomRepository 에서 동적으로
 	// 쿼리를 생성해서 처리

--- a/eeos/src/main/java/com/blackcompany/eeos/member/persistence/JpaMemberRepository.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/persistence/JpaMemberRepository.java
@@ -33,6 +33,15 @@ public interface JpaMemberRepository extends JpaRepository<MemberEntity, Long> {
 	List<MemberEntity> findSlackOnlyMembers(
 			@Param("oauthServerType") OauthServerType oauthServerType);
 
+	@Query(
+			"SELECT m FROM MemberEntity m WHERE m.oauthServerType = :oauthServerType"
+					+ " AND m.name LIKE :generationPrefix"
+					+ " AND m.isDeleted = false"
+					+ " AND m.id NOT IN (SELECT a.memberId FROM AccountEntity a WHERE a.isDeleted=false)")
+	List<MemberEntity> findSlackOnlyMembersByGeneration(
+			@Param("oauthServerType") OauthServerType oauthServerType,
+			@Param("generationPrefix") String generationPrefix);
+
 	// 동작하지 않는 쿼리 : SQL 의 FILED 함수 내에 List<Long> 이 들어갈 때, 단일 파라미터로 들어가기 때문에 CustomRepository 에서 동적으로
 	// 쿼리를 생성해서 처리
 	//	@Query("SELECT m FROM MemberEntity m WHERE m.id IN :ids AND m.isDeleted=false ORDER BY

--- a/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberRepositoryImpl.java
@@ -80,4 +80,14 @@ public class MemberRepositoryImpl implements MemberRepository {
 				.map(converter::from)
 				.toList();
 	}
+
+	@Override
+	public List<MemberModel> findSlackOnlyMembersByGeneration(int generation) {
+		String generationPrefix = generation + "기 %";
+		return jpaRepository
+				.findSlackOnlyMembersByGeneration(OauthServerType.SLACK, generationPrefix)
+				.stream()
+				.map(converter::from)
+				.toList();
+	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberRepositoryImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/persistence/MemberRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.member.persistence;
 
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
 import com.blackcompany.eeos.member.application.exception.NotFoundMemberException;
 import com.blackcompany.eeos.member.application.model.ActiveStatus;
 import com.blackcompany.eeos.member.application.model.MemberModel;
@@ -71,5 +72,12 @@ public class MemberRepositoryImpl implements MemberRepository {
 	@Override
 	public String findNameById(Long memberId) {
 		return jpaRepository.findNameById(memberId).orElseThrow(NotFoundMemberException::new);
+	}
+
+	@Override
+	public List<MemberModel> findSlackOnlyMembers() {
+		return jpaRepository.findSlackOnlyMembers(OauthServerType.SLACK).stream()
+				.map(converter::from)
+				.toList();
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/controller/MemberController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/controller/MemberController.java
@@ -17,6 +17,7 @@ import com.blackcompany.eeos.member.application.usecase.DepartmentUsecase;
 import com.blackcompany.eeos.member.application.usecase.GetMemberByActiveStatus;
 import com.blackcompany.eeos.member.application.usecase.GetMembersByActiveStatus;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMemberUsecase;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersByGenerationUsecase;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import com.blackcompany.eeos.member.presentation.docs.MemberApi;
 import jakarta.validation.Valid;
@@ -43,6 +44,8 @@ public class MemberController implements MemberApi {
 	private final DepartmentUsecase departmentUsecase;
 	private final SendSignupLinkToSlackOnlyMembersUsecase sendSignupLinkToSlackOnlyMembersUsecase;
 	private final SendSignupLinkToSlackOnlyMemberUsecase sendSignupLinkToSlackOnlyMemberUsecase;
+	private final SendSignupLinkToSlackOnlyMembersByGenerationUsecase
+			sendSignupLinkToSlackOnlyMembersByGenerationUsecase;
 
 	@Override
 	@PutMapping("/activeStatus/{memberId}")
@@ -95,7 +98,7 @@ public class MemberController implements MemberApi {
 	}
 
 	@Override
-	@PostMapping("/admin/slack-signup-dm")
+	@PostMapping("/admin/signup-dm")
 	public ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDm(
 			@Member Long adminMemberId) {
 		SlackSignupDmResponse response =
@@ -104,11 +107,21 @@ public class MemberController implements MemberApi {
 	}
 
 	@Override
-	@PostMapping("/admin/{memberId}/slack-signup-dm")
+	@PostMapping("/admin/signup-dm/{memberId}")
 	public ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDmToMember(
 			@Member Long adminMemberId, @PathVariable("memberId") Long memberId) {
 		SlackSignupDmResponse response =
 				sendSignupLinkToSlackOnlyMemberUsecase.sendSignupLink(adminMemberId, memberId);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.CREATE);
+	}
+
+	@Override
+	@PostMapping("/admin/signup-dm/gen/{generation}")
+	public ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDmByGeneration(
+			@Member Long adminMemberId, @PathVariable("generation") int generation) {
+		SlackSignupDmResponse response =
+				sendSignupLinkToSlackOnlyMembersByGenerationUsecase.sendSignupLinksByGeneration(
+						adminMemberId, generation);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.CREATE);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/controller/MemberController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/controller/MemberController.java
@@ -10,11 +10,13 @@ import com.blackcompany.eeos.member.application.dto.CommandMemberResponse;
 import com.blackcompany.eeos.member.application.dto.DepartmentResponse;
 import com.blackcompany.eeos.member.application.dto.QueryMemberResponse;
 import com.blackcompany.eeos.member.application.dto.QueryMembersResponse;
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
 import com.blackcompany.eeos.member.application.model.Department;
 import com.blackcompany.eeos.member.application.usecase.ChangeActiveStatusUsecase;
 import com.blackcompany.eeos.member.application.usecase.DepartmentUsecase;
 import com.blackcompany.eeos.member.application.usecase.GetMemberByActiveStatus;
 import com.blackcompany.eeos.member.application.usecase.GetMembersByActiveStatus;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import com.blackcompany.eeos.member.presentation.docs.MemberApi;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -23,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +40,7 @@ public class MemberController implements MemberApi {
 	private final GetMembersByActiveStatus getMembersByActiveStatus;
 	private final GetMemberByActiveStatus getMemberByActiveStatus;
 	private final DepartmentUsecase departmentUsecase;
+	private final SendSignupLinkToSlackOnlyMembersUsecase sendSignupLinkToSlackOnlyMembersUsecase;
 
 	@Override
 	@PutMapping("/activeStatus/{memberId}")
@@ -86,5 +90,14 @@ public class MemberController implements MemberApi {
 		List<DepartmentResponse> responses =
 				departments.stream().map(DepartmentResponse::from).toList();
 		return ApiResponseGenerator.success(responses, HttpStatus.OK, MessageCode.GET);
+	}
+
+	@Override
+	@PostMapping("/admin/slack-signup-dm")
+	public ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDm(
+			@Member Long adminMemberId) {
+		SlackSignupDmResponse response =
+				sendSignupLinkToSlackOnlyMembersUsecase.sendSignupLinks(adminMemberId);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.CREATE);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/controller/MemberController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/controller/MemberController.java
@@ -16,6 +16,7 @@ import com.blackcompany.eeos.member.application.usecase.ChangeActiveStatusUsecas
 import com.blackcompany.eeos.member.application.usecase.DepartmentUsecase;
 import com.blackcompany.eeos.member.application.usecase.GetMemberByActiveStatus;
 import com.blackcompany.eeos.member.application.usecase.GetMembersByActiveStatus;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMemberUsecase;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import com.blackcompany.eeos.member.presentation.docs.MemberApi;
 import jakarta.validation.Valid;
@@ -41,6 +42,7 @@ public class MemberController implements MemberApi {
 	private final GetMemberByActiveStatus getMemberByActiveStatus;
 	private final DepartmentUsecase departmentUsecase;
 	private final SendSignupLinkToSlackOnlyMembersUsecase sendSignupLinkToSlackOnlyMembersUsecase;
+	private final SendSignupLinkToSlackOnlyMemberUsecase sendSignupLinkToSlackOnlyMemberUsecase;
 
 	@Override
 	@PutMapping("/activeStatus/{memberId}")
@@ -98,6 +100,15 @@ public class MemberController implements MemberApi {
 			@Member Long adminMemberId) {
 		SlackSignupDmResponse response =
 				sendSignupLinkToSlackOnlyMembersUsecase.sendSignupLinks(adminMemberId);
+		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.CREATE);
+	}
+
+	@Override
+	@PostMapping("/admin/{memberId}/slack-signup-dm")
+	public ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDmToMember(
+			@Member Long adminMemberId, @PathVariable("memberId") Long memberId) {
+		SlackSignupDmResponse response =
+				sendSignupLinkToSlackOnlyMemberUsecase.sendSignupLink(adminMemberId, memberId);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.CREATE);
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
@@ -65,7 +65,7 @@ public interface MemberApi {
 				description = "DM 발송 완료. 성공/실패 건수를 반환합니다."),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "403",
-				description = "3000: 관리자 권한이 없습니다",
+				description = "3004: 관리자 권한이 없습니다",
 				content = @Content)
 	})
 	ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDm(

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
@@ -70,4 +70,31 @@ public interface MemberApi {
 	})
 	ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDm(
 			@Parameter(hidden = true) @Member Long adminMemberId);
+
+	@Operation(
+			summary = "관리자_특정 Slack 전용 회원에게 회원가입 링크 DM 발송",
+			description =
+					"지정한 회원이 Slack 전용(EEOS 계정 없음) 회원인 경우 해당 회원에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다."
+							+ " 관리자 권한이 필요합니다.",
+			security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "200",
+				description = "DM 발송 완료. 성공/실패 건수를 반환합니다."),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "403",
+				description = "3004: 관리자 권한이 없습니다",
+				content = @Content),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "404",
+				description = "3000: 존재하지 않는 멤버입니다",
+				content = @Content),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "409",
+				description = "4203: Slack 전용 회원이 아닙니다",
+				content = @Content)
+	})
+	ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDmToMember(
+			@Parameter(hidden = true) @Member Long adminMemberId,
+			@PathVariable("memberId") Long memberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
@@ -97,4 +97,23 @@ public interface MemberApi {
 	ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDmToMember(
 			@Parameter(hidden = true) @Member Long adminMemberId,
 			@PathVariable("memberId") Long memberId);
+
+	@Operation(
+			summary = "관리자_기수별 Slack 전용 회원 회원가입 링크 DM 발송",
+			description =
+					"지정한 기수의 Slack 전용(EEOS 계정 없음) 회원 전체에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다."
+							+ " 관리자 권한이 필요합니다.",
+			security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "200",
+				description = "DM 발송 완료. 성공/실패 건수를 반환합니다."),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "403",
+				description = "3004: 관리자 권한이 없습니다",
+				content = @Content)
+	})
+	ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDmByGeneration(
+			@Parameter(hidden = true) @Member Long adminMemberId,
+			@PathVariable("generation") int generation);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/member/presentation/docs/MemberApi.java
@@ -8,8 +8,12 @@ import com.blackcompany.eeos.member.application.dto.CommandMemberResponse;
 import com.blackcompany.eeos.member.application.dto.DepartmentResponse;
 import com.blackcompany.eeos.member.application.dto.QueryMemberResponse;
 import com.blackcompany.eeos.member.application.dto.QueryMembersResponse;
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,4 +52,22 @@ public interface MemberApi {
 
 	@Operation(summary = "관리자_부서 리스트 조회", description = "동아리 내의 부서 리스트를 반환합니다.")
 	ApiResponse<SuccessBody<List<DepartmentResponse>>> getDepartments();
+
+	@Operation(
+			summary = "관리자_Slack 전용 회원 회원가입 링크 DM 발송",
+			description =
+					"Slack OAuth2로만 가입된(EEOS ID/PW 계정이 없는) 회원 전체에게 EEOS 회원가입 링크를 Slack DM으로 발송합니다."
+							+ " 관리자 권한이 필요합니다.",
+			security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "200",
+				description = "DM 발송 완료. 성공/실패 건수를 반환합니다."),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "403",
+				description = "3000: 관리자 권한이 없습니다",
+				content = @Content)
+	})
+	ApiResponse<SuccessBody<SlackSignupDmResponse>> sendSlackSignupDm(
+			@Parameter(hidden = true) @Member Long adminMemberId);
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/program/infra/api/slack/chat/client/SlackChatApiClient.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/infra/api/slack/chat/client/SlackChatApiClient.java
@@ -1,8 +1,11 @@
 package com.blackcompany.eeos.program.infra.api.slack.chat.client;
 
 import com.blackcompany.eeos.program.infra.api.slack.chat.dto.SlackChatPostMessageResponse;
+import com.blackcompany.eeos.program.infra.api.slack.chat.dto.SlackConversationOpenResponse;
 
 public interface SlackChatApiClient {
+
+	SlackConversationOpenResponse openConversation(final String token, final String users);
 
 	SlackChatPostMessageResponse post(
 			final String token, final String channel, final String blocks, final String username);

--- a/eeos/src/main/java/com/blackcompany/eeos/program/infra/api/slack/chat/client/SlackChatApiClientImpl.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/infra/api/slack/chat/client/SlackChatApiClientImpl.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.program.infra.api.slack.chat.client;
 
 import com.blackcompany.eeos.program.infra.api.slack.chat.dto.SlackChatPostMessageResponse;
+import com.blackcompany.eeos.program.infra.api.slack.chat.dto.SlackConversationOpenResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +10,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "SlackChatOpenFeign", url = "https://slack.com/api")
 public interface SlackChatApiClientImpl extends SlackChatApiClient {
+
+	@PostMapping(path = "/conversations.open", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	SlackConversationOpenResponse openConversation(
+			@RequestHeader("Authorization") String token, @RequestParam("users") final String users);
 
 	@PostMapping(path = "/chat.postMessage", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
 	SlackChatPostMessageResponse post(

--- a/eeos/src/main/java/com/blackcompany/eeos/program/infra/api/slack/chat/dto/SlackConversationOpenResponse.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/program/infra/api/slack/chat/dto/SlackConversationOpenResponse.java
@@ -1,0 +1,41 @@
+package com.blackcompany.eeos.program.infra.api.slack.chat.dto;
+
+import com.blackcompany.eeos.auth.infra.oauth.slack.dto.SlackApiResponse;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SlackConversationOpenResponse implements SlackApiResponse {
+
+	private boolean ok;
+	private Channel channel;
+	private String error;
+
+	@Override
+	public String getError() {
+		return error;
+	}
+
+	public String getChannelId() {
+		return channel != null ? channel.getId() : null;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder
+	public static class Channel {
+		private String id;
+
+		@JsonProperty("is_im")
+		private boolean isIm;
+
+		private String user;
+	}
+}

--- a/eeos/src/main/resources/application-api.yml
+++ b/eeos/src/main/resources/application-api.yml
@@ -15,7 +15,7 @@ token:
 eeos:
   internal-api-key: ${EEOS_INTERNAL_API_KEY:}
   signup:
-    url: ${EEOS_SIGNUP_URL:https://auth.econovation.kr/signup}
+    url: ${EEOS_SIGNUP_URL:https://auth.econovation.kr}
     code-secret: ${EEOS_SLACK_SIGNUP_CODE_SECRET}
 
 auth:

--- a/eeos/src/main/resources/application-api.yml
+++ b/eeos/src/main/resources/application-api.yml
@@ -16,6 +16,7 @@ eeos:
   internal-api-key: ${EEOS_INTERNAL_API_KEY:}
   signup:
     url: ${EEOS_SIGNUP_URL:https://auth.econovation.kr/signup}
+    code-secret: ${EEOS_SLACK_SIGNUP_CODE_SECRET}
 
 auth:
   login-page-url: ${AUTH_LOGIN_PAGE_URL:http://localhost:3000/login}

--- a/eeos/src/main/resources/application-api.yml
+++ b/eeos/src/main/resources/application-api.yml
@@ -14,6 +14,8 @@ token:
 
 eeos:
   internal-api-key: ${EEOS_INTERNAL_API_KEY:}
+  signup:
+    url: ${EEOS_SIGNUP_URL:https://auth.econovation.kr/signup}
 
 auth:
   login-page-url: ${AUTH_LOGIN_PAGE_URL:http://localhost:3000/login}

--- a/eeos/src/main/resources/application-slack.yml
+++ b/eeos/src/main/resources/application-slack.yml
@@ -17,6 +17,8 @@ slack:
       eeos: ${BLACK_COMPANY_EEOS_BOT_TOKEN}
     econovation:
       eeos: ${ECONOVATION_EEOS_BOT_TOKEN}
+    dm:
+      token: ${SLACK_DM_BOT_TOKEN:${ECONOVATION_EEOS_BOT_TOKEN}}
 
   channel:
     black-company:

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -154,8 +154,7 @@ class EeosSignUpServiceTest {
 		when(accountRepository.existsByMemberId(memberId)).thenReturn(true);
 
 		assertThrows(
-				AlreadyLinkedAccountException.class,
-				() -> eeosSignUpService.signUp(command, slackUserId));
+				AlreadyLinkedAccountException.class, () -> eeosSignUpService.signUp(command, slackUserId));
 
 		verify(accountRepository, never()).save(any());
 		verify(tokenGenerator, never()).execute(any(), any());

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -124,7 +124,7 @@ class EeosSignUpServiceTest {
 
 		assertEquals(expectedToken, result);
 		verify(accountRepository).save(any(AccountModel.class));
-		verify(authorityRepository).save(any(AuthorityModel.class));
+		verify(authorityRepository, never()).save(any(AuthorityModel.class));
 	}
 
 	@Test

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -7,16 +7,25 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.blackcompany.eeos.auth.application.domain.OauthMemberModel;
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
 import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+import com.blackcompany.eeos.auth.application.exception.AlreadyLinkedAccountException;
 import com.blackcompany.eeos.auth.application.exception.DuplicateLoginIdException;
+import com.blackcompany.eeos.auth.application.exception.SlackMemberNotFoundException;
+import com.blackcompany.eeos.auth.application.model.AccountModel;
+import com.blackcompany.eeos.auth.application.model.AuthorityModel;
 import com.blackcompany.eeos.auth.application.model.Role;
 import com.blackcompany.eeos.auth.application.repository.AccountRepository;
 import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
+import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
 import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
+import com.blackcompany.eeos.auth.fixture.FakeOauthMember;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +40,7 @@ class EeosSignUpServiceTest {
 	@Mock MemberRepository memberRepository;
 	@Mock AccountRepository accountRepository;
 	@Mock AuthorityRepository authorityRepository;
+	@Mock OAuthMemberRepository oAuthMemberRepository;
 	@Mock EncryptHelper encryptHelper;
 	@Mock AuthenticationTokenGenerator tokenGenerator;
 
@@ -81,6 +91,89 @@ class EeosSignUpServiceTest {
 		assertThrows(DuplicateLoginIdException.class, () -> eeosSignUpService.signUp(command));
 
 		verify(memberRepository, never()).save(any());
+		verify(accountRepository, never()).save(any());
+		verify(tokenGenerator, never()).execute(any(), any());
+	}
+
+	@Test
+	@DisplayName("slackMemberId에 해당하는 회원이 존재하고 Account가 없으면 Account를 생성하고 토큰을 반환한다.")
+	void signUp_withSlackMemberId_savesAccountAndReturnsToken() {
+		String slackUserId = "U_SLACK_001";
+		Long memberId = 10L;
+		String loginId = "testUser";
+		String rawPassword = "password123";
+		String encryptedPassword = "encrypted_password123";
+
+		EeosSignUpCommand command = new EeosSignUpCommand(loginId, rawPassword, 15, "홍길동", "am");
+		OauthMemberModel oauthMember =
+				FakeOauthMember.oauthMemberModel(OauthServerType.SLACK, memberId);
+		TokenModel expectedToken =
+				TokenModel.builder().accessToken("access_token").refreshToken("refresh_token").build();
+
+		when(accountRepository.existsByLoginId(loginId)).thenReturn(false);
+		when(oAuthMemberRepository.findByOauthId(slackUserId)).thenReturn(Optional.of(oauthMember));
+		when(accountRepository.existsByMemberId(memberId)).thenReturn(false);
+		when(encryptHelper.encrypt(rawPassword)).thenReturn(encryptedPassword);
+		when(tokenGenerator.execute(memberId, Set.of(Role.ROLE_USER.name()))).thenReturn(expectedToken);
+
+		TokenModel result = eeosSignUpService.signUp(command, slackUserId);
+
+		assertEquals(expectedToken, result);
+		verify(accountRepository).save(any(AccountModel.class));
+		verify(authorityRepository).save(any(AuthorityModel.class));
+	}
+
+	@Test
+	@DisplayName("slackMemberId에 해당하는 OAuthMember가 없으면 SlackMemberNotFoundException이 발생한다.")
+	void signUp_withSlackMemberId_whenOAuthMemberNotFound_throwsSlackMemberNotFoundException() {
+		String slackUserId = "U_NOT_EXIST";
+		EeosSignUpCommand command = new EeosSignUpCommand("testUser", "password", 15, "홍길동", "am");
+
+		when(accountRepository.existsByLoginId("testUser")).thenReturn(false);
+		when(oAuthMemberRepository.findByOauthId(slackUserId)).thenReturn(Optional.empty());
+
+		assertThrows(
+				SlackMemberNotFoundException.class, () -> eeosSignUpService.signUp(command, slackUserId));
+
+		verify(accountRepository, never()).save(any());
+		verify(tokenGenerator, never()).execute(any(), any());
+	}
+
+	@Test
+	@DisplayName(
+			"slackMemberId에 해당하는 Member에 이미 Account가 연결되어 있으면 AlreadyLinkedAccountException이 발생한다.")
+	void signUp_withSlackMemberId_whenAlreadyLinked_throwsAlreadyLinkedAccountException() {
+		String slackUserId = "U_SLACK_LINKED";
+		Long memberId = 20L;
+		EeosSignUpCommand command = new EeosSignUpCommand("testUser", "password", 15, "홍길동", "am");
+		OauthMemberModel oauthMember =
+				FakeOauthMember.oauthMemberModel(OauthServerType.SLACK, memberId);
+
+		when(accountRepository.existsByLoginId("testUser")).thenReturn(false);
+		when(oAuthMemberRepository.findByOauthId(slackUserId)).thenReturn(Optional.of(oauthMember));
+		when(accountRepository.existsByMemberId(memberId)).thenReturn(true);
+
+		assertThrows(
+				AlreadyLinkedAccountException.class,
+				() -> eeosSignUpService.signUp(command, slackUserId));
+
+		verify(accountRepository, never()).save(any());
+		verify(tokenGenerator, never()).execute(any(), any());
+	}
+
+	@Test
+	@DisplayName("이미 사용 중인 아이디로 Slack 연동 회원가입하면 DuplicateLoginIdException이 발생한다.")
+	void signUp_withSlackMemberId_whenDuplicateLoginId_throwsDuplicateLoginIdException() {
+		String slackUserId = "U_SLACK_001";
+		String loginId = "existingId";
+		EeosSignUpCommand command = new EeosSignUpCommand(loginId, "password123", 15, "홍길동", "am");
+
+		when(accountRepository.existsByLoginId(loginId)).thenReturn(true);
+
+		assertThrows(
+				DuplicateLoginIdException.class, () -> eeosSignUpService.signUp(command, slackUserId));
+
+		verify(oAuthMemberRepository, never()).findByOauthId(any());
 		verify(accountRepository, never()).save(any());
 		verify(tokenGenerator, never()).execute(any(), any());
 	}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/application/service/EeosSignUpServiceTest.java
@@ -22,6 +22,7 @@ import com.blackcompany.eeos.auth.application.repository.AuthorityRepository;
 import com.blackcompany.eeos.auth.application.repository.OAuthMemberRepository;
 import com.blackcompany.eeos.auth.application.support.AuthenticationTokenGenerator;
 import com.blackcompany.eeos.auth.application.support.EncryptHelper;
+import com.blackcompany.eeos.auth.application.support.SlackSignupCodeEncoder;
 import com.blackcompany.eeos.auth.fixture.FakeOauthMember;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
@@ -43,6 +44,7 @@ class EeosSignUpServiceTest {
 	@Mock OAuthMemberRepository oAuthMemberRepository;
 	@Mock EncryptHelper encryptHelper;
 	@Mock AuthenticationTokenGenerator tokenGenerator;
+	@Mock SlackSignupCodeEncoder slackSignupCodeEncoder;
 
 	@InjectMocks EeosSignUpService eeosSignUpService;
 
@@ -96,8 +98,9 @@ class EeosSignUpServiceTest {
 	}
 
 	@Test
-	@DisplayName("slackMemberId에 해당하는 회원이 존재하고 Account가 없으면 Account를 생성하고 토큰을 반환한다.")
-	void signUp_withSlackMemberId_savesAccountAndReturnsToken() {
+	@DisplayName("유효한 code로 Slack 연동 회원가입하면 Account를 생성하고 토큰을 반환한다.")
+	void signUp_withCode_savesAccountAndReturnsToken() {
+		String code = "encrypted_U_SLACK_001";
 		String slackUserId = "U_SLACK_001";
 		Long memberId = 10L;
 		String loginId = "testUser";
@@ -110,13 +113,14 @@ class EeosSignUpServiceTest {
 		TokenModel expectedToken =
 				TokenModel.builder().accessToken("access_token").refreshToken("refresh_token").build();
 
+		when(slackSignupCodeEncoder.decode(code)).thenReturn(slackUserId);
 		when(accountRepository.existsByLoginId(loginId)).thenReturn(false);
 		when(oAuthMemberRepository.findByOauthId(slackUserId)).thenReturn(Optional.of(oauthMember));
 		when(accountRepository.existsByMemberId(memberId)).thenReturn(false);
 		when(encryptHelper.encrypt(rawPassword)).thenReturn(encryptedPassword);
 		when(tokenGenerator.execute(memberId, Set.of(Role.ROLE_USER.name()))).thenReturn(expectedToken);
 
-		TokenModel result = eeosSignUpService.signUp(command, slackUserId);
+		TokenModel result = eeosSignUpService.signUp(command, code);
 
 		assertEquals(expectedToken, result);
 		verify(accountRepository).save(any(AccountModel.class));
@@ -124,37 +128,39 @@ class EeosSignUpServiceTest {
 	}
 
 	@Test
-	@DisplayName("slackMemberId에 해당하는 OAuthMember가 없으면 SlackMemberNotFoundException이 발생한다.")
-	void signUp_withSlackMemberId_whenOAuthMemberNotFound_throwsSlackMemberNotFoundException() {
+	@DisplayName("code에 해당하는 OAuthMember가 없으면 SlackMemberNotFoundException이 발생한다.")
+	void signUp_withCode_whenOAuthMemberNotFound_throwsSlackMemberNotFoundException() {
+		String code = "encrypted_U_NOT_EXIST";
 		String slackUserId = "U_NOT_EXIST";
 		EeosSignUpCommand command = new EeosSignUpCommand("testUser", "password", 15, "홍길동", "am");
 
+		when(slackSignupCodeEncoder.decode(code)).thenReturn(slackUserId);
 		when(accountRepository.existsByLoginId("testUser")).thenReturn(false);
 		when(oAuthMemberRepository.findByOauthId(slackUserId)).thenReturn(Optional.empty());
 
-		assertThrows(
-				SlackMemberNotFoundException.class, () -> eeosSignUpService.signUp(command, slackUserId));
+		assertThrows(SlackMemberNotFoundException.class, () -> eeosSignUpService.signUp(command, code));
 
 		verify(accountRepository, never()).save(any());
 		verify(tokenGenerator, never()).execute(any(), any());
 	}
 
 	@Test
-	@DisplayName(
-			"slackMemberId에 해당하는 Member에 이미 Account가 연결되어 있으면 AlreadyLinkedAccountException이 발생한다.")
-	void signUp_withSlackMemberId_whenAlreadyLinked_throwsAlreadyLinkedAccountException() {
+	@DisplayName("code에 해당하는 Member에 이미 Account가 연결되어 있으면 AlreadyLinkedAccountException이 발생한다.")
+	void signUp_withCode_whenAlreadyLinked_throwsAlreadyLinkedAccountException() {
+		String code = "encrypted_U_SLACK_LINKED";
 		String slackUserId = "U_SLACK_LINKED";
 		Long memberId = 20L;
 		EeosSignUpCommand command = new EeosSignUpCommand("testUser", "password", 15, "홍길동", "am");
 		OauthMemberModel oauthMember =
 				FakeOauthMember.oauthMemberModel(OauthServerType.SLACK, memberId);
 
+		when(slackSignupCodeEncoder.decode(code)).thenReturn(slackUserId);
 		when(accountRepository.existsByLoginId("testUser")).thenReturn(false);
 		when(oAuthMemberRepository.findByOauthId(slackUserId)).thenReturn(Optional.of(oauthMember));
 		when(accountRepository.existsByMemberId(memberId)).thenReturn(true);
 
 		assertThrows(
-				AlreadyLinkedAccountException.class, () -> eeosSignUpService.signUp(command, slackUserId));
+				AlreadyLinkedAccountException.class, () -> eeosSignUpService.signUp(command, code));
 
 		verify(accountRepository, never()).save(any());
 		verify(tokenGenerator, never()).execute(any(), any());
@@ -162,16 +168,16 @@ class EeosSignUpServiceTest {
 
 	@Test
 	@DisplayName("이미 사용 중인 아이디로 Slack 연동 회원가입하면 DuplicateLoginIdException이 발생한다.")
-	void signUp_withSlackMemberId_whenDuplicateLoginId_throwsDuplicateLoginIdException() {
-		String slackUserId = "U_SLACK_001";
+	void signUp_withCode_whenDuplicateLoginId_throwsDuplicateLoginIdException() {
+		String code = "encrypted_U_SLACK_001";
 		String loginId = "existingId";
 		EeosSignUpCommand command = new EeosSignUpCommand(loginId, "password123", 15, "홍길동", "am");
 
 		when(accountRepository.existsByLoginId(loginId)).thenReturn(true);
 
-		assertThrows(
-				DuplicateLoginIdException.class, () -> eeosSignUpService.signUp(command, slackUserId));
+		assertThrows(DuplicateLoginIdException.class, () -> eeosSignUpService.signUp(command, code));
 
+		verify(slackSignupCodeEncoder, never()).decode(any());
 		verify(oAuthMemberRepository, never()).findByOauthId(any());
 		verify(accountRepository, never()).save(any());
 		verify(tokenGenerator, never()).execute(any(), any());

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/AuthControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/AuthControllerTest.java
@@ -1,0 +1,141 @@
+package com.blackcompany.eeos.auth.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.blackcompany.eeos.auth.application.domain.TokenModel;
+import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
+import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
+import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+import com.blackcompany.eeos.auth.application.usecase.EeosSignUpUseCase;
+import com.blackcompany.eeos.auth.application.usecase.LogOutUsecase;
+import com.blackcompany.eeos.auth.application.usecase.LoginUsecase;
+import com.blackcompany.eeos.auth.application.usecase.OAuthSignUpUseCase;
+import com.blackcompany.eeos.auth.application.usecase.ReissueUsecase;
+import com.blackcompany.eeos.auth.application.usecase.WithDrawUsecase;
+import com.blackcompany.eeos.auth.presentation.support.AuthCookieManager;
+import com.blackcompany.eeos.auth.presentation.support.TokenExtractor;
+import com.blackcompany.eeos.common.presentation.support.CookieManager;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+	private MockMvc mockMvc;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Mock private LoginUsecase loginUsecase;
+	@Mock private ReissueUsecase reissueUsecase;
+	@Mock private TokenExtractor tokenExtractor;
+	@Mock private CookieManager cookieManager;
+	@Mock private AuthCookieManager authCookieManager;
+	@Spy private TokenResponseConverter tokenResponseConverter;
+	@Mock private LogOutUsecase logOutUsecase;
+	@Mock private WithDrawUsecase withDrawUsecase;
+	@Mock private OAuthSignUpUseCase oAuthSignUpUseCase;
+	@Mock private EeosSignUpUseCase eeosSignUpUseCase;
+	@Mock private TokenResolver tokenResolver;
+
+	private AuthController authController;
+
+	private final TokenModel tokenModel =
+			TokenModel.builder()
+					.accessToken("test-at")
+					.refreshToken("test-rt")
+					.accessExpiredTime(9999999L)
+					.refreshExpiredTime(19999999L)
+					.build();
+
+	@BeforeEach
+	void setUp() {
+		authController =
+				new AuthController(
+						loginUsecase,
+						reissueUsecase,
+						tokenExtractor,
+						tokenResponseConverter,
+						cookieManager,
+						authCookieManager,
+						logOutUsecase,
+						withDrawUsecase,
+						oAuthSignUpUseCase,
+						eeosSignUpUseCase,
+						tokenResolver);
+		mockMvc = MockMvcBuilders.standaloneSetup(authController).build();
+	}
+
+	@Test
+	@DisplayName("slackMemberId가 없으면 일반 회원가입 유스케이스를 호출한다.")
+	void signUp_withoutSlackMemberId_usesEeosSignUpUseCase() throws Exception {
+		when(eeosSignUpUseCase.signUp(any(EeosSignUpCommand.class))).thenReturn(tokenModel);
+		when(cookieManager.setCookie(any(), any()))
+				.thenReturn(ResponseCookie.from("eeos_token", "test-rt").path("/").build());
+
+		mockMvc
+				.perform(
+						post("/api/auth/signup")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(
+										objectMapper.writeValueAsString(
+												Map.of(
+														"id", "testuser",
+														"password", "test1234",
+														"generation", 30,
+														"name", "홍길동",
+														"activeStatus", "am"))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.accessToken").value("test-at"))
+				.andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("test-rt")));
+
+		verify(eeosSignUpUseCase).signUp(any(EeosSignUpCommand.class));
+		verify(eeosSignUpUseCase, never()).signUp(any(EeosSignUpCommand.class), any());
+	}
+
+	@Test
+	@DisplayName("slackMemberId가 있으면 동일 가입 유스케이스의 Slack 연동 메소드를 호출한다.")
+	void signUp_withSlackMemberId_usesEeosSignUpUseCaseOverload() throws Exception {
+		when(eeosSignUpUseCase.signUp(any(EeosSignUpCommand.class), eq("U08ABCDE123")))
+				.thenReturn(tokenModel);
+		when(cookieManager.setCookie(any(), any()))
+				.thenReturn(ResponseCookie.from("eeos_token", "test-rt").path("/").build());
+
+		mockMvc
+				.perform(
+						post("/api/auth/signup")
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(
+										objectMapper.writeValueAsString(
+												Map.of(
+														"id", "testuser",
+														"password", "test1234",
+														"generation", 30,
+														"name", "홍길동",
+														"activeStatus", "am",
+														"slackMemberId", "U08ABCDE123"))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.accessToken").value("test-at"))
+				.andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("test-rt")));
+
+		verify(eeosSignUpUseCase).signUp(any(EeosSignUpCommand.class), eq("U08ABCDE123"));
+		verify(eeosSignUpUseCase, never()).signUp(any(EeosSignUpCommand.class));
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/AuthControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/AuthControllerTest.java
@@ -98,7 +98,7 @@ class AuthControllerTest {
 										objectMapper.writeValueAsString(
 												Map.of(
 														"id", "testuser",
-														"password", "test1234",
+														"password", "test1234!",
 														"generation", 30,
 														"name", "홍길동",
 														"activeStatus", "am"))))
@@ -127,7 +127,7 @@ class AuthControllerTest {
 										objectMapper.writeValueAsString(
 												Map.of(
 														"id", "testuser",
-														"password", "test1234",
+														"password", "test1234!",
 														"generation", 30,
 														"name", "홍길동",
 														"activeStatus", "am"))))

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/AuthControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/AuthControllerTest.java
@@ -121,6 +121,7 @@ class AuthControllerTest {
 		mockMvc
 				.perform(
 						post("/api/auth/signup")
+								.param("code", "U08ABCDE123")
 								.contentType(MediaType.APPLICATION_JSON)
 								.content(
 										objectMapper.writeValueAsString(
@@ -129,8 +130,7 @@ class AuthControllerTest {
 														"password", "test1234",
 														"generation", 30,
 														"name", "홍길동",
-														"activeStatus", "am",
-														"slackMemberId", "U08ABCDE123"))))
+														"activeStatus", "am"))))
 				.andExpect(status().isCreated())
 				.andExpect(jsonPath("$.data.accessToken").value("test-at"))
 				.andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("test-rt")));

--- a/eeos/src/test/java/com/blackcompany/eeos/member/application/service/MemberRepositoryTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/application/service/MemberRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.blackcompany.eeos.member.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blackcompany.eeos.auth.application.domain.OauthServerType;
+import com.blackcompany.eeos.auth.application.model.AccountModel;
+import com.blackcompany.eeos.auth.application.repository.AccountRepository;
+import com.blackcompany.eeos.common.DataClearExtension;
+import com.blackcompany.eeos.member.application.model.ActiveStatus;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@ExtendWith(DataClearExtension.class)
+class MemberRepositoryTest {
+
+	@Autowired private MemberRepository memberRepository;
+	@Autowired private AccountRepository accountRepository;
+
+	@Test
+	@DisplayName("Account가 없는 Slack OAuth 회원은 Slack Only 회원 목록에 조회된다.")
+	void findSlackOnlyMembers_slackMemberWithoutAccount_isIncluded() {
+		// given
+		MemberModel slackOnlyMember =
+				MemberModel.builder()
+						.name("슬랙전용회원")
+						.oauthServerType(OauthServerType.SLACK)
+						.activeStatus(ActiveStatus.AM)
+						.isAdmin(false)
+						.build();
+		MemberModel saved = memberRepository.save(slackOnlyMember);
+
+		// when
+		List<MemberModel> result = memberRepository.findSlackOnlyMembers();
+
+		// then
+		assertThat(result).extracting(MemberModel::getId).contains(saved.getId());
+	}
+
+	@Test
+	@DisplayName("Account가 있는 Slack OAuth 회원은 Slack Only 회원 목록에 조회되지 않는다.")
+	void findSlackOnlyMembers_slackMemberWithAccount_isExcluded() {
+		// given
+		MemberModel slackMemberWithAccount =
+				MemberModel.builder()
+						.name("계정있는슬랙회원")
+						.oauthServerType(OauthServerType.SLACK)
+						.activeStatus(ActiveStatus.AM)
+						.isAdmin(false)
+						.build();
+		MemberModel saved = memberRepository.save(slackMemberWithAccount);
+
+		// Account를 직접 저장하여 해당 Member에 Account가 연결된 상태를 만든다
+		AccountModel account =
+				AccountModel.builder()
+						.memberId(saved.getId())
+						.loginId("linked_user_" + saved.getId())
+						.password("encrypted_pw")
+						.build();
+		accountRepository.save(account);
+
+		// when
+		List<MemberModel> result = memberRepository.findSlackOnlyMembers();
+
+		// then
+		assertThat(result).extracting(MemberModel::getId).doesNotContain(saved.getId());
+	}
+
+	@Test
+	@DisplayName("Account가 없는 일반(non-Slack) 회원은 Slack Only 회원 목록에 조회되지 않는다.")
+	void findSlackOnlyMembers_nonSlackMemberWithoutAccount_isExcluded() {
+		// given
+		MemberModel eeosOnlyMember =
+				MemberModel.builder()
+						.name("이오스전용회원")
+						.oauthServerType(OauthServerType.EEOS)
+						.activeStatus(ActiveStatus.AM)
+						.isAdmin(false)
+						.build();
+		MemberModel saved = memberRepository.save(eeosOnlyMember);
+
+		// when
+		List<MemberModel> result = memberRepository.findSlackOnlyMembers();
+
+		// then
+		assertThat(result).extracting(MemberModel::getId).doesNotContain(saved.getId());
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
@@ -1,0 +1,99 @@
+package com.blackcompany.eeos.member.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+import com.blackcompany.eeos.member.application.model.MemberModel;
+import com.blackcompany.eeos.member.application.repository.MemberRepository;
+import com.blackcompany.eeos.member.fixture.MemberFixture;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SendSignupLinkServiceTest {
+
+	@Mock MemberRepository memberRepository;
+	@Mock SlackDmNotificationService slackDmNotificationService;
+
+	@InjectMocks SendSignupLinkService sendSignupLinkService;
+
+	@Test
+	@DisplayName("Slack Only 회원이 0명일 때 DM 발송 없이 totalCount=0 결과를 반환한다.")
+	void sendDm_noSlackOnlyMembers_returnZeroCount() {
+		// given
+		when(memberRepository.findById(1L)).thenReturn(MemberFixture.어드민_모델(1L));
+		when(memberRepository.findSlackOnlyMembers()).thenReturn(Collections.emptyList());
+
+		// when
+		SlackSignupDmResponse result = sendSignupLinkService.sendSignupLinks(1L);
+
+		// then
+		assertEquals(0, result.getTotalCount());
+		assertEquals(0, result.getSuccessCount());
+		assertEquals(0, result.getFailCount());
+		verify(slackDmNotificationService, never()).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("Slack Only 회원이 있을 때 successCount가 대상 수와 같아야 한다.")
+	void sendDm_allSuccess_successCountEqualsTargetSize() {
+		// given
+		List<MemberModel> targets =
+				List.of(MemberFixture.슬랙온리_모델(2L, "U_SLACK_001"), MemberFixture.슬랙온리_모델(3L, "U_SLACK_002"));
+
+		when(memberRepository.findById(1L)).thenReturn(MemberFixture.어드민_모델(1L));
+		when(memberRepository.findSlackOnlyMembers()).thenReturn(targets);
+
+		// when
+		SlackSignupDmResponse result = sendSignupLinkService.sendSignupLinks(1L);
+
+		// then
+		assertEquals(2, result.getTotalCount());
+		assertEquals(2, result.getSuccessCount());
+		assertEquals(0, result.getFailCount());
+		verify(slackDmNotificationService, times(2)).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("DM 발송 중 일부 실패 시 failCount가 증가하고 전체 발송이 중단되지 않는다.")
+	void sendDm_partialFailure_failCountIncreased_noAbort() {
+		// given
+		MemberModel member1 = MemberFixture.슬랙온리_모델(2L, "U_SLACK_001");
+		MemberModel member2 = MemberFixture.슬랙온리_모델(3L, "U_SLACK_002");
+		MemberModel member3 = MemberFixture.슬랙온리_모델(4L, "U_SLACK_003");
+
+		List<MemberModel> targets = List.of(member1, member2, member3);
+		when(memberRepository.findById(1L)).thenReturn(MemberFixture.어드민_모델(1L));
+		when(memberRepository.findSlackOnlyMembers()).thenReturn(targets);
+
+		doThrow(new RuntimeException("Slack API error"))
+				.when(slackDmNotificationService)
+				.sendSignupLink(eq(member2), anyString());
+
+		// when
+		SlackSignupDmResponse result = sendSignupLinkService.sendSignupLinks(1L);
+
+		// then
+		assertEquals(3, result.getTotalCount());
+		assertEquals(2, result.getSuccessCount());
+		assertEquals(1, result.getFailCount());
+		verify(slackDmNotificationService, times(3)).sendSignupLink(any(), anyString());
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+import com.blackcompany.eeos.member.application.exception.DeniedMemberEditException;
 import com.blackcompany.eeos.member.application.exception.NotSlackOnlyMemberException;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
@@ -171,5 +172,106 @@ class SendSignupLinkServiceTest {
 		assertEquals(1, result.getTotalCount());
 		assertEquals(0, result.getSuccessCount());
 		assertEquals(1, result.getFailCount());
+	}
+
+	// =====================================================================
+	// 기수별 Slack 회원가입 DM 발송 테스트
+	// =====================================================================
+
+	@Test
+	@DisplayName("해당 기수에 Slack 전용 회원이 있을 때 해당 인원에게 DM을 성공적으로 발송한다.")
+	void sendSignupLinksByGeneration_성공_해당기수_슬랙온리회원_DM발송() {
+		// given
+		int generation = 12;
+		Long adminMemberId = 1L;
+		MemberModel admin = MemberFixture.어드민_모델(adminMemberId);
+		List<MemberModel> targets =
+				List.of(
+						MemberFixture.기수별_슬랙온리_모델(2L, generation, "홍길동"),
+						MemberFixture.기수별_슬랙온리_모델(3L, generation, "김철수"));
+
+		when(memberRepository.findById(adminMemberId)).thenReturn(admin);
+		when(memberRepository.findSlackOnlyMembersByGeneration(generation)).thenReturn(targets);
+
+		// when
+		SlackSignupDmResponse result =
+				sendSignupLinkService.sendSignupLinksByGeneration(adminMemberId, generation);
+
+		// then
+		assertEquals(2, result.getTotalCount());
+		assertEquals(2, result.getSuccessCount());
+		assertEquals(0, result.getFailCount());
+		verify(slackDmNotificationService, times(2)).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("해당 기수에 Slack 전용 회원이 없을 때 DM 발송 없이 totalCount=0 결과를 반환한다.")
+	void sendSignupLinksByGeneration_성공_대상없음_빈결과반환() {
+		// given
+		int generation = 99;
+		Long adminMemberId = 1L;
+		MemberModel admin = MemberFixture.어드민_모델(adminMemberId);
+
+		when(memberRepository.findById(adminMemberId)).thenReturn(admin);
+		when(memberRepository.findSlackOnlyMembersByGeneration(generation))
+				.thenReturn(Collections.emptyList());
+
+		// when
+		SlackSignupDmResponse result =
+				sendSignupLinkService.sendSignupLinksByGeneration(adminMemberId, generation);
+
+		// then
+		assertEquals(0, result.getTotalCount());
+		assertEquals(0, result.getSuccessCount());
+		assertEquals(0, result.getFailCount());
+		verify(slackDmNotificationService, never()).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("기수별 DM 발송 중 일부 Slack API 호출이 실패하면 failCount가 증가하고 나머지 발송은 계속된다.")
+	void sendSignupLinksByGeneration_부분실패_failCount증가_발송중단없음() {
+		// given
+		int generation = 12;
+		Long adminMemberId = 1L;
+		MemberModel admin = MemberFixture.어드민_모델(adminMemberId);
+		MemberModel member1 = MemberFixture.기수별_슬랙온리_모델(2L, generation, "홍길동");
+		MemberModel member2 = MemberFixture.기수별_슬랙온리_모델(3L, generation, "김철수");
+		MemberModel member3 = MemberFixture.기수별_슬랙온리_모델(4L, generation, "이영희");
+
+		when(memberRepository.findById(adminMemberId)).thenReturn(admin);
+		when(memberRepository.findSlackOnlyMembersByGeneration(generation))
+				.thenReturn(List.of(member1, member2, member3));
+		doThrow(new RuntimeException("Slack API error"))
+				.when(slackDmNotificationService)
+				.sendSignupLink(eq(member2), anyString());
+
+		// when
+		SlackSignupDmResponse result =
+				sendSignupLinkService.sendSignupLinksByGeneration(adminMemberId, generation);
+
+		// then
+		assertEquals(3, result.getTotalCount());
+		assertEquals(2, result.getSuccessCount());
+		assertEquals(1, result.getFailCount());
+		verify(slackDmNotificationService, times(3)).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("관리자가 아닌 회원이 기수별 DM 발송을 요청하면 DeniedMemberEditException이 발생한다.")
+	void sendSignupLinksByGeneration_실패_관리자아닌회원_예외발생() {
+		// given
+		int generation = 12;
+		Long nonAdminMemberId = 5L;
+		MemberModel nonAdmin =
+				MemberFixture.멤버_모델(
+						nonAdminMemberId, com.blackcompany.eeos.member.application.model.ActiveStatus.AM);
+
+		when(memberRepository.findById(nonAdminMemberId)).thenReturn(nonAdmin);
+
+		// when & then
+		assertThrows(
+				DeniedMemberEditException.class,
+				() -> sendSignupLinkService.sendSignupLinksByGeneration(nonAdminMemberId, generation));
+		verify(slackDmNotificationService, never()).sendSignupLink(any(), anyString());
 	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
@@ -1,6 +1,7 @@
 package com.blackcompany.eeos.member.application.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+import com.blackcompany.eeos.member.application.exception.NotSlackOnlyMemberException;
 import com.blackcompany.eeos.member.application.model.MemberModel;
 import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import com.blackcompany.eeos.member.fixture.MemberFixture;
@@ -102,5 +104,72 @@ class SendSignupLinkServiceTest {
 		assertEquals(2, result.getSuccessCount());
 		assertEquals(1, result.getFailCount());
 		verify(slackDmNotificationService, times(3)).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("Slack Only 회원에게 단건 DM 발송 성공 시 successCount=1 결과를 반환한다.")
+	void sendSignupLink_성공_슬랙온리회원에게_DM발송_성공() {
+		// given
+		Long adminMemberId = 1L;
+		Long targetMemberId = 2L;
+		MemberModel admin = MemberFixture.어드민_모델(adminMemberId);
+		MemberModel target = MemberFixture.슬랙온리_모델(targetMemberId, "U_SLACK_001");
+
+		when(memberRepository.findById(adminMemberId)).thenReturn(admin);
+		when(memberRepository.findById(targetMemberId)).thenReturn(target);
+
+		// when
+		SlackSignupDmResponse result =
+				sendSignupLinkService.sendSignupLink(adminMemberId, targetMemberId);
+
+		// then
+		assertEquals(1, result.getTotalCount());
+		assertEquals(1, result.getSuccessCount());
+		assertEquals(0, result.getFailCount());
+		verify(slackDmNotificationService, times(1)).sendSignupLink(eq(target), anyString());
+	}
+
+	@Test
+	@DisplayName("대상 회원이 Slack Only가 아닌 경우 NotSlackOnlyMemberException이 발생한다.")
+	void sendSignupLink_실패_슬랙온리아닌회원_예외발생() {
+		// given
+		Long adminMemberId = 1L;
+		Long targetMemberId = 3L;
+		MemberModel admin = MemberFixture.어드민_모델(adminMemberId);
+		MemberModel nonSlackOnlyMember = MemberFixture.비슬랙온리_모델(targetMemberId);
+
+		when(memberRepository.findById(adminMemberId)).thenReturn(admin);
+		when(memberRepository.findById(targetMemberId)).thenReturn(nonSlackOnlyMember);
+
+		// when & then
+		assertThrows(
+				NotSlackOnlyMemberException.class,
+				() -> sendSignupLinkService.sendSignupLink(adminMemberId, targetMemberId));
+		verify(slackDmNotificationService, never()).sendSignupLink(any(), anyString());
+	}
+
+	@Test
+	@DisplayName("단건 DM 발송 중 슬랙 API 예외 발생 시 failCount=1 결과를 반환한다.")
+	void sendSignupLink_실패_DM발송_예외_failCount증가() {
+		// given
+		Long adminMemberId = 1L;
+		Long targetMemberId = 2L;
+		MemberModel admin = MemberFixture.어드민_모델(adminMemberId);
+		MemberModel target = MemberFixture.슬랙온리_모델(targetMemberId, "U_SLACK_001");
+
+		when(memberRepository.findById(adminMemberId)).thenReturn(admin);
+		when(memberRepository.findById(targetMemberId)).thenReturn(target);
+		doThrow(new RuntimeException("Slack API error"))
+				.when(slackDmNotificationService)
+				.sendSignupLink(eq(target), anyString());
+
+		// when
+		SlackSignupDmResponse result =
+				sendSignupLinkService.sendSignupLink(adminMemberId, targetMemberId);
+
+		// then
+		assertEquals(1, result.getTotalCount());
+		assertEquals(0, result.getSuccessCount());
+		assertEquals(1, result.getFailCount());
 	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/application/service/SendSignupLinkServiceTest.java
@@ -16,10 +16,10 @@ import com.blackcompany.eeos.member.application.repository.MemberRepository;
 import com.blackcompany.eeos.member.fixture.MemberFixture;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -32,7 +32,14 @@ class SendSignupLinkServiceTest {
 	@Mock MemberRepository memberRepository;
 	@Mock SlackDmNotificationService slackDmNotificationService;
 
-	@InjectMocks SendSignupLinkService sendSignupLinkService;
+	SendSignupLinkService sendSignupLinkService;
+
+	@BeforeEach
+	void setUp() {
+		sendSignupLinkService =
+				new SendSignupLinkService(
+						memberRepository, slackDmNotificationService, "https://auth.econovation.kr");
+	}
 
 	@Test
 	@DisplayName("Slack Only 회원이 0명일 때 DM 발송 없이 totalCount=0 결과를 반환한다.")

--- a/eeos/src/test/java/com/blackcompany/eeos/member/fixture/MemberFixture.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/fixture/MemberFixture.java
@@ -45,4 +45,14 @@ public class MemberFixture {
 				.isAdmin(true)
 				.build();
 	}
+
+	public static MemberModel 슬랙온리_모델(Long memberId, String slackUserId) {
+		return MemberModel.builder()
+				.id(memberId)
+				.name(String.valueOf(memberId))
+				.oauthServerType(OauthServerType.SLACK)
+				.activeStatus(ActiveStatus.AM)
+				.isAdmin(false)
+				.build();
+	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/member/fixture/MemberFixture.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/fixture/MemberFixture.java
@@ -55,4 +55,14 @@ public class MemberFixture {
 				.isAdmin(false)
 				.build();
 	}
+
+	public static MemberModel 비슬랙온리_모델(Long memberId) {
+		return MemberModel.builder()
+				.id(memberId)
+				.name(String.valueOf(memberId))
+				.oauthServerType(OauthServerType.EEOS)
+				.activeStatus(ActiveStatus.AM)
+				.isAdmin(false)
+				.build();
+	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/member/fixture/MemberFixture.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/fixture/MemberFixture.java
@@ -65,4 +65,14 @@ public class MemberFixture {
 				.isAdmin(false)
 				.build();
 	}
+
+	public static MemberModel 기수별_슬랙온리_모델(Long memberId, int generation, String memberName) {
+		return MemberModel.builder()
+				.id(memberId)
+				.name(generation + "기 " + memberName)
+				.oauthServerType(OauthServerType.SLACK)
+				.activeStatus(ActiveStatus.AM)
+				.isAdmin(false)
+				.build();
+	}
 }

--- a/eeos/src/test/java/com/blackcompany/eeos/member/presentation/controller/MemberControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/presentation/controller/MemberControllerTest.java
@@ -1,0 +1,50 @@
+package com.blackcompany.eeos.member.presentation.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.blackcompany.eeos.common.presentation.response.ApiResponse;
+import com.blackcompany.eeos.common.presentation.response.ApiResponseBody.SuccessBody;
+import com.blackcompany.eeos.member.application.dto.SlackSignupDmResponse;
+import com.blackcompany.eeos.member.application.usecase.ChangeActiveStatusUsecase;
+import com.blackcompany.eeos.member.application.usecase.DepartmentUsecase;
+import com.blackcompany.eeos.member.application.usecase.GetMemberByActiveStatus;
+import com.blackcompany.eeos.member.application.usecase.GetMembersByActiveStatus;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+
+	@Mock private ChangeActiveStatusUsecase changeActiveStatusUsecase;
+	@Mock private GetMembersByActiveStatus getMembersByActiveStatus;
+	@Mock private GetMemberByActiveStatus getMemberByActiveStatus;
+	@Mock private DepartmentUsecase departmentUsecase;
+	@Mock private SendSignupLinkToSlackOnlyMembersUsecase sendSignupLinkToSlackOnlyMembersUsecase;
+
+	@InjectMocks private MemberController memberController;
+
+	@Test
+	@DisplayName("관리자 Slack 회원가입 DM 발송 요청 시 집계 결과를 반환한다.")
+	void sendSlackSignupDm_returnsAggregatedResponse() {
+		SlackSignupDmResponse response =
+				SlackSignupDmResponse.builder().totalCount(12).successCount(11).failCount(1).build();
+		when(sendSignupLinkToSlackOnlyMembersUsecase.sendSignupLinks(1L)).thenReturn(response);
+
+		ApiResponse<SuccessBody<SlackSignupDmResponse>> result = memberController.sendSlackSignupDm(1L);
+
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("201", result.getBody().getCode());
+		assertEquals(12, result.getBody().getData().getTotalCount());
+		assertEquals(11, result.getBody().getData().getSuccessCount());
+		assertEquals(1, result.getBody().getData().getFailCount());
+		verify(sendSignupLinkToSlackOnlyMembersUsecase).sendSignupLinks(1L);
+	}
+}

--- a/eeos/src/test/java/com/blackcompany/eeos/member/presentation/controller/MemberControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/member/presentation/controller/MemberControllerTest.java
@@ -11,6 +11,7 @@ import com.blackcompany.eeos.member.application.usecase.ChangeActiveStatusUsecas
 import com.blackcompany.eeos.member.application.usecase.DepartmentUsecase;
 import com.blackcompany.eeos.member.application.usecase.GetMemberByActiveStatus;
 import com.blackcompany.eeos.member.application.usecase.GetMembersByActiveStatus;
+import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMemberUsecase;
 import com.blackcompany.eeos.member.application.usecase.SendSignupLinkToSlackOnlyMembersUsecase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ class MemberControllerTest {
 	@Mock private GetMemberByActiveStatus getMemberByActiveStatus;
 	@Mock private DepartmentUsecase departmentUsecase;
 	@Mock private SendSignupLinkToSlackOnlyMembersUsecase sendSignupLinkToSlackOnlyMembersUsecase;
+	@Mock private SendSignupLinkToSlackOnlyMemberUsecase sendSignupLinkToSlackOnlyMemberUsecase;
 
 	@InjectMocks private MemberController memberController;
 
@@ -46,5 +48,29 @@ class MemberControllerTest {
 		assertEquals(11, result.getBody().getData().getSuccessCount());
 		assertEquals(1, result.getBody().getData().getFailCount());
 		verify(sendSignupLinkToSlackOnlyMembersUsecase).sendSignupLinks(1L);
+	}
+
+	@Test
+	@DisplayName("특정 회원에게 Slack 회원가입 DM 발송 요청 시 집계 결과를 반환한다.")
+	void sendSlackSignupDmToMember_성공_집계결과_반환() {
+		// given
+		Long adminMemberId = 1L;
+		Long targetMemberId = 2L;
+		SlackSignupDmResponse response =
+				SlackSignupDmResponse.builder().totalCount(1).successCount(1).failCount(0).build();
+		when(sendSignupLinkToSlackOnlyMemberUsecase.sendSignupLink(adminMemberId, targetMemberId))
+				.thenReturn(response);
+
+		// when
+		ApiResponse<SuccessBody<SlackSignupDmResponse>> result =
+				memberController.sendSlackSignupDmToMember(adminMemberId, targetMemberId);
+
+		// then
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("201", result.getBody().getCode());
+		assertEquals(1, result.getBody().getData().getTotalCount());
+		assertEquals(1, result.getBody().getData().getSuccessCount());
+		assertEquals(0, result.getBody().getData().getFailCount());
+		verify(sendSignupLinkToSlackOnlyMemberUsecase).sendSignupLink(adminMemberId, targetMemberId);
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈

closes #335

## ✒️ 작업 내용

### Slack OAuth2 전용 회원 가입 링크 DM 일괄 발송
- `POST /api/members/admin/slack-signup-dm` 어드민 전용 엔드포인트 추가
- Slack OAuth 전용 회원(Account 미연결) 조회 후 개인 DM으로 가입 링크 일괄 발송
- DM 발송 전 `conversations.open`으로 채널 확보 후 `chat.postMessage` 전송
- 개별 발송 실패 시 집계(totalCount / successCount / failCount)하고 전체 처리 계속 진행

### Slack 가입 링크 code 암호화
- DM 링크에 포함되는 Slack User ID를 AES/GCM으로 암호화해 `?code=` 쿼리 파라미터로 전달
- `SlackSignupCodeEncoder` 추가 (AES-256, Base64 URL-safe 인코딩)
- 복호화 실패 시 `InvalidSignupCodeException` (4202) 반환

### Slack 연동 회원가입 분기
- 기존 `POST /api/auth/signup`에 `?code=` 쿼리 파라미터 추가 (optional)
- `code` 있음 → 복호화 후 기존 Slack OAuth 회원에 Account 연결 (Member 신규 생성 없음)
- `code` 없음 → 기존 로직 (새 Member + Account 생성)
- 존재하지 않는 code: `SlackMemberNotFoundException` (4200)
- 이미 Account 연결된 회원: `AlreadyLinkedAccountException` (4201)

### 테스트 / 문서
- `EeosSignUpServiceTest`, `SendSignupLinkServiceTest` 추가 및 보강
- `auth_README.md`, `member_README.md` API 명세 반영

## 💬 REVIEWER에게 요구사항 💬

- Slack DM 발송 플로우(`conversations.open` → `chat.postMessage`)의 예외 처리 및 로그 포맷이 운영 관점에서 충분한지 검토 부탁드립니다.
- 관리자 DM 발송 API의 부분 실패 허용 정책이 의도에 맞는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Slack 코드 링크 기반 가입 분기 및 Slack DM으로 전송되는 회원가입 링크(일괄/개별) 관리자 API 추가
  * Slack DM 전송 클라이언트/응답 처리 및 가입 코드 암호화/복호화 지원 추가
* **오류 처리**
  * Slack 회원 미존재, 이미 연결된 계정, 유효하지 않은 가입 코드, 비슬랙 회원 대상 오류 등 명확한 도메인 오류 코드 추가
* **문서**
  * 인증·회원 API 동작, 에러 코드 및 사용 사례 문서화 추가
* **테스트**
  * Slack 코드 가입, 컨트롤러, 저장소, DM 전송 서비스 단위·통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->