### PR TITLE
fix: PR #328에서 제거된 OAuth/일반 로그인 API 복원

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/AuthController.java
@@ -4,7 +4,9 @@ import com.blackcompany.eeos.auth.application.domain.TokenModel;
 import com.blackcompany.eeos.auth.application.domain.token.TokenResolver;
 import com.blackcompany.eeos.auth.application.dto.converter.TokenResponseConverter;
 import com.blackcompany.eeos.auth.application.dto.request.AdditionalInfoApplicationCommand;
+import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
 import com.blackcompany.eeos.auth.application.dto.request.EeosSignUpCommand;
+import com.blackcompany.eeos.auth.application.dto.request.OAuthLoginRequestCommand;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
 import com.blackcompany.eeos.auth.application.usecase.*;
 import com.blackcompany.eeos.auth.presentation.docs.AuthApi;
@@ -28,9 +30,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -71,6 +75,39 @@ public class AuthController implements AuthApi {
 		this.oAuthSignUpUseCase = oAuthSignUpUseCase;
 		this.eeosSignUpUseCase = eeosSignUpUseCase;
 		this.tokenResolver = tokenResolver;
+	}
+
+	@Override
+	@PostMapping("/login/{oauthServerType}")
+	public ApiResponse<SuccessBody<TokenResponse>> login(
+			@PathVariable String oauthServerType,
+			@RequestParam("code") String code,
+			@RequestParam("redirect_uri") String uri,
+			HttpServletResponse httpResponse) {
+		String formatUri = uri.trim().replaceAll("[\n\r\t ]", "");
+
+		OAuthLoginRequestCommand command =
+				new OAuthLoginRequestCommand(oauthServerType, code, formatUri);
+		TokenModel tokenModel = loginUsecase.login(command);
+
+		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
+
+		// 마이그레이션 필요 체크 - 임시 코드
+		HttpHeaders headers = new HttpHeaders();
+		if ("slack".equals(oauthServerType)) {
+			headers.add("Migration-Required", "true");
+		}
+
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, headers, MessageCode.CREATE);
+	}
+
+	@Override
+	@PostMapping("/login")
+	public ApiResponse<SuccessBody<TokenResponse>> login(
+			@RequestBody EEOSLoginRequest request, HttpServletResponse httpResponse) {
+		TokenModel tokenModel = loginUsecase.login(request.getId(), request.getPassword());
+		TokenResponse response = generateTokenResponse(tokenModel, httpResponse);
+		return ApiResponseGenerator.success(response, HttpStatus.CREATED, MessageCode.CREATE);
 	}
 
 	@Override

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/AuthApi.java
@@ -1,5 +1,6 @@
 package com.blackcompany.eeos.auth.presentation.docs;
 
+import com.blackcompany.eeos.auth.application.dto.request.EEOSLoginRequest;
 import com.blackcompany.eeos.auth.application.dto.response.TokenResponse;
 import com.blackcompany.eeos.auth.presentation.dto.EeosSignUpRequest;
 import com.blackcompany.eeos.auth.presentation.support.Member;
@@ -14,10 +15,37 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "인증", description = "인증 관련 API")
 public interface AuthApi {
+	@Operation(
+			summary = "OAuth 로그인",
+			description = "PathVariable에 담긴 redirect_url, code를 받아 액세스 토큰과 리프레시 토큰을 발급한다.")
+	ApiResponse<SuccessBody<TokenResponse>> login(
+			@Parameter(description = "OAuth 서버 타입 (예: slack)", required = true) @PathVariable
+					String oauthServerType,
+			@Parameter(description = "OAuth 인증 코드", required = true) @RequestParam("code") String code,
+			@Parameter(description = "리다이렉트 URI", required = true) @RequestParam("redirect_uri")
+					String uri,
+			HttpServletResponse httpResponse);
+
+	@Operation(summary = "일반 로그인", description = "사용자가 id와 password를 이용하여 로그인한다.")
+	@ApiResponses({
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "200",
+				description = "로그인 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "401",
+				description = "4008: ID 또는 비밀번호가 일치하지 않습니다",
+				content = @Content)
+	})
+	ApiResponse<SuccessBody<TokenResponse>> login(
+			@Parameter(description = "로그인 요청 정보", required = true) @RequestBody EEOSLoginRequest request,
+			HttpServletResponse httpResponse);
+
 	@Operation(summary = "회원가입", description = "id, password, 기수, 성함, 활동상태로 회원가입하고 토큰을 반환한다.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(


### PR DESCRIPTION
## 변경 배경

PR #328 (Web/App 인증 분리 + PKCE 도입) 작업 중 기존에 있던 두 로그인 엔드포인트가 의도치 않게 제거됨.

## 변경 내용

- `POST /api/auth/login/{oauthServerType}` — OAuth 로그인 API 복원 (code, redirect_uri 파라미터)
- `POST /api/auth/login` — 일반(id/password) 로그인 API 복원
- `AuthController`, `AuthApi` (Swagger docs) 모두 복원

## 검증

- 서버 로컬 실행 후 smoke test 확인
  - `POST /api/auth/login` 올바른 credentials → 201 + accessToken 정상 발급
  - `POST /api/auth/login` 잘못된 credentials → 401
  - `POST /api/auth/login/{oauthServerType}` 엔드포인트 등록 확인 (404/405 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * OAuth 기반 로그인 기능 추가 (다양한 OAuth 제공자 지원)
  * 기본 자격증명 로그인 엔드포인트 추가

* **Documentation**
  * 로그인 API 엔드포인트 문서 업데이트 및 인증 실패 응답 코드 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->