### PR TITLE
fix: 비밀번호 유효성 규칙을 영문·숫자·특수기호 필수 조합으로 변경

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequest.java
@@ -21,8 +21,8 @@ public class EeosSignUpRequest {
 
 	@NotBlank(message = "4102:비밀번호는 필수 입력값입니다")
 	@Pattern(
-			regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
-			message = "4103:비밀번호는 8~20자이며, 영문과 숫자를 포함해야 합니다")
+			regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$",
+			message = "4103:비밀번호는 8~20자이며, 영문·숫자·특수기호를 포함해야 합니다")
 	private String password;
 
 	@NotNull(message = "4104:기수는 필수 입력값입니다")

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/dto/EeosSignUpRequestTest.java
@@ -30,8 +30,15 @@ class EeosSignUpRequestTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"password1", "Password1", "abc12345", "ABCD1234", "abcd1234efgh5678"})
-	@DisplayName("영문+숫자 조합 8~20자 비밀번호는 유효하다.")
+	@ValueSource(
+			strings = {
+				"password1!", // 소문자+숫자+특수기호
+				"PASSWORD1!", // 대문자+숫자+특수기호
+				"Password1!", // 대소문자+숫자+특수기호
+				"abc1234@", // 소문자+숫자+특수기호 8자
+				"ABC1234@", // 대문자+숫자+특수기호 8자
+			})
+	@DisplayName("영문+숫자+특수기호 조합 8~20자 비밀번호는 유효하다.")
 	void valid_password(String password) {
 		EeosSignUpRequest request = new EeosSignUpRequest("testId", password, 15, "홍길동", "am");
 
@@ -42,7 +49,15 @@ class EeosSignUpRequestTest {
 
 	@ParameterizedTest
 	@ValueSource(
-			strings = {"short1", "onlyletters", "12345678", "!special1", "toolongpassword12345678"})
+			strings = {
+				"Ab1!xyz", // 7자 (8자 미만)
+				"onlyletters", // 숫자/특수기호 없음
+				"12345678", // 영문/특수기호 없음
+				"Password1", // 특수기호 없음
+				"password!!", // 숫자 없음
+				"1234567!", // 영문 없음
+				"Pass1!Pass1!Pass1!Pass1!", // 20자 초과
+			})
 	@DisplayName("조건을 만족하지 않는 비밀번호는 유효하지 않다.")
 	void invalid_password(String password) {
 		EeosSignUpRequest request = new EeosSignUpRequest("testId", password, 15, "홍길동", "am");


### PR DESCRIPTION
## 변경 배경

기존 비밀번호 규칙은 영문+숫자 조합만 요구했으며 특수기호를 허용하지 않았습니다.
보안 강화를 위해 특수기호를 필수로 포함하도록 규칙을 변경합니다.

## 변경 내용

- 기존: 영문+숫자 조합 8~20자 (`[A-Za-z\d]{8,20}`)
- 변경: 영문+숫자+특수기호 모두 포함 8~20자

| 조건 | 기존 | 변경 후 |
|------|------|---------|
| 영문 (대소문자 무관) | 필수 | 필수 |
| 숫자 | 필수 | 필수 |
| 특수기호 | 불가 | **필수** |
| 길이 | 8~20자 | 8~20자 |

## 테스트 확인

- [x] `password1!` (소문자+숫자+특수기호) → 유효
- [x] `PASSWORD1!` (대문자+숫자+특수기호) → 유효
- [x] `Password1` (특수기호 없음) → 유효하지 않음
- [x] `password!!` (숫자 없음) → 유효하지 않음
- [x] `1234567!` (영문 없음) → 유효하지 않음
- [x] 단위 테스트 12/12 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 회원가입 비밀번호 보안 요구사항이 강화되었습니다.
  * 비밀번호는 이제 8-20자의 영문, 숫자, 특수기호를 모두 포함해야 합니다.
  * 관련 검증 오류 메시지가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->