### PR TITLE
[REFACTOR] CD 모니터링 에러 해결 및 알림 에러 디버깅용 로그 코드 추가

### DIFF
--- a/eeos/docker-compose-dev.yml
+++ b/eeos/docker-compose-dev.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   nginx-proxy:
     container_name: nginx-proxy
@@ -79,9 +78,13 @@ services:
       SPRING_REDIS_PASSWORD: root
     networks:
       - internal-network
+      - monitoring-shared
       - external-network
 
 networks:
   internal-network:
   external-network:
+  monitoring-shared:
+    external: true
+    name: monitoring-shared
 

--- a/eeos/docker-compose-local.yml
+++ b/eeos/docker-compose-local.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   eeos-mysql:
     container_name: eeos-mysql

--- a/eeos/docker-compose-monitoring.yml
+++ b/eeos/docker-compose-monitoring.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   prometheus:
     build:
@@ -17,8 +16,8 @@ services:
       -c "envsubst '$$PROD_SERVER_IP' < /etc/prometheus/prometheus.yml.template > /etc/prometheus/prometheus.yml && /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle"
     restart: always
     networks:
-      - internal-network
-      - external-network
+      - monitoring-internal
+      - monitoring-shared
 
   grafana:
     image: grafana/grafana:latest
@@ -37,11 +36,11 @@ services:
       - prometheus
     restart: always
     networks:
-      - internal-network
-      - external-network
+      - monitoring-internal
 networks:
-  internal-network:
-  external-network:
+  monitoring-internal:
+  monitoring-shared:
+    name: monitoring-shared
 
 volumes:
   prometheus-data:

--- a/eeos/docker-compose-prod.yml
+++ b/eeos/docker-compose-prod.yml
@@ -1,4 +1,3 @@
-version: '3.1'
 services:
   nginx-proxy:
     container_name: nginx-proxy

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/infra/fcm/FCMErrorMapper.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/infra/fcm/FCMErrorMapper.java
@@ -3,13 +3,22 @@ package com.blackcompany.eeos.notification.infra.fcm;
 import com.blackcompany.eeos.notification.application.port.NotificationErrorCode;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MessagingErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class FCMErrorMapper {
 	public NotificationErrorCode map(FirebaseMessagingException e) {
 
 		MessagingErrorCode errorCode = e.getMessagingErrorCode();
+
+		log.warn(
+				"FCM 발송 실패 - messagingErrorCode={}, errorCode={}, httpStatus={}, message={}",
+				errorCode,
+				e.getErrorCode(),
+				e.getHttpResponse() != null ? e.getHttpResponse().getStatusCode() : "N/A",
+				e.getMessage());
 
 		if (errorCode == null) {
 			return NotificationErrorCode.UNKNOWN_ERROR;

--- a/eeos/src/main/java/com/blackcompany/eeos/notification/infra/fcm/FCMNotificationSender.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/notification/infra/fcm/FCMNotificationSender.java
@@ -16,8 +16,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FCMNotificationSender implements NotificationSender {
@@ -75,7 +77,9 @@ public class FCMNotificationSender implements NotificationSender {
 				if (sendResponse.isSuccessful()) {
 					results.put(token, NotificationResult.success());
 				} else {
-					NotificationErrorCode errorCode = fcmErrorMapper.map(sendResponse.getException());
+					FirebaseMessagingException exception = sendResponse.getException();
+					log.warn("FCM 발송 실패 - token={}, message={}", token, exception.getMessage());
+					NotificationErrorCode errorCode = fcmErrorMapper.map(exception);
 					results.put(token, NotificationResult.fail(errorCode));
 				}
 			}


### PR DESCRIPTION
## 📌 관련 이슈
closes #349 
## ✒️ 작업 내용
### 모니터링 작업 배경
- dev 환경 재배포 시 `docker-compose -f docker-compose-dev.yml down`이
`error while removing network: ... has active endpoints` 에러로 실패
- 원인: dev/monitoring compose가 같은 `internal-network` 이름을 공유해 단일
네트워크로 머지 → grafana/prometheus가 endpoint로 남아 dev `down`을 차단
### 모니터링 관련 변경사항
- **monitoring compose**: 네트워크를 `monitoring-internal`(prometheus ↔ grafana)과
`monitoring-shared`(eeos-backend ↔ prometheus 다리)로 분리
- **dev compose**: `eeos-backend`가 `monitoring-shared`에 `external: true`로 join.
네트워크 소유권은 monitoring compose에 둠
- 양쪽에 `name: monitoring-shared` 명시해 Compose 프로젝트명 prefix 회피
- 양쪽 compose `version: '3.1'` 제거 (deprecated, `name:` 속성 사용을 위해 필요)

### 알림 에러 로깅 코드 추가
- UNKOWN_ERROR 관련 FCM 에러 로그 디버깅을 위한 로깅 코드 추가




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker Compose 설정 파일 구조 단순화 및 네트워크 구성 개선
  
* **Bug Fixes**
  * 푸시 알림 전송 실패 시 상세 로깅 추가 (에러 코드, HTTP 상태 등)
  * 알림 배송 에러 매핑 및 추적 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->