### PR TITLE
fix: OAuth2 웹 로그인 CORS 에러 해결 (303 리다이렉트 → 200 + redirectUrl)

### DIFF
--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2Controller.java
@@ -76,7 +76,7 @@ public class OAuth2Controller implements OAuth2Api {
 
 	@Override
 	@PostMapping("/login")
-	public ResponseEntity<Void> login(
+	public ResponseEntity<Map<String, String>> login(
 			@RequestParam("client_id") String clientId,
 			@RequestParam("redirect_uri") String redirectUri,
 			@RequestParam("state") String state,
@@ -89,7 +89,7 @@ public class OAuth2Controller implements OAuth2Api {
 
 		var client = validateClientOrBadRequest(clientId, redirectUri);
 		if (client == null) {
-			return ResponseEntity.badRequest().build();
+			return ResponseEntity.badRequest().body(Map.of("error", "invalid_client"));
 		}
 
 		String ip = request.getRemoteAddr();
@@ -141,7 +141,7 @@ public class OAuth2Controller implements OAuth2Api {
 		}
 	}
 
-	private ResponseEntity<Void> handleWebLogin(
+	private ResponseEntity<Map<String, String>> handleWebLogin(
 			String clientId,
 			String redirectUri,
 			String state,
@@ -157,18 +157,16 @@ public class OAuth2Controller implements OAuth2Api {
 		response.addHeader(HttpHeaders.SET_COOKIE, atCookie.toString());
 		response.addHeader(HttpHeaders.SET_COOKIE, rtCookie.toString());
 
-		String location =
+		String redirectUrl =
 				UriComponentsBuilder.fromUriString(redirectUri)
 						.queryParam("state", state)
 						.build()
 						.toUriString();
 
-		return ResponseEntity.status(HttpStatus.SEE_OTHER)
-				.header(HttpHeaders.LOCATION, location)
-				.build();
+		return ResponseEntity.ok(Map.of("redirectUrl", redirectUrl));
 	}
 
-	private ResponseEntity<Void> handleAppLogin(
+	private ResponseEntity<Map<String, String>> handleAppLogin(
 			String clientId,
 			String redirectUri,
 			String state,
@@ -181,25 +179,23 @@ public class OAuth2Controller implements OAuth2Api {
 				oAuth2LoginService.loginForApp(
 						clientId, redirectUri, email, password, ip, codeChallenge, codeChallengeMethod);
 
-		String location =
+		String redirectUrl =
 				UriComponentsBuilder.fromUriString(redirectUri)
 						.queryParam("code", code)
 						.queryParam("state", state)
 						.build()
 						.toUriString();
 
-		return ResponseEntity.status(HttpStatus.SEE_OTHER)
-				.header(HttpHeaders.LOCATION, location)
-				.build();
+		return ResponseEntity.ok(Map.of("redirectUrl", redirectUrl));
 	}
 
-	private ResponseEntity<Void> redirectToLoginPageWithError(
+	private ResponseEntity<Map<String, String>> redirectToLoginPageWithError(
 			String clientId,
 			String redirectUri,
 			String state,
 			String codeChallenge,
 			String codeChallengeMethod) {
-		String location =
+		String redirectUrl =
 				UriComponentsBuilder.fromUriString(loginPageUrl)
 						.queryParam("client_id", clientId)
 						.queryParam("redirect_uri", redirectUri)
@@ -211,8 +207,6 @@ public class OAuth2Controller implements OAuth2Api {
 						.build()
 						.toUriString();
 
-		return ResponseEntity.status(HttpStatus.SEE_OTHER)
-				.header(HttpHeaders.LOCATION, location)
-				.build();
+		return ResponseEntity.ok(Map.of("redirectUrl", redirectUrl, "error", "invalid_credentials"));
 	}
 }

--- a/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
+++ b/eeos/src/main/java/com/blackcompany/eeos/auth/presentation/docs/OAuth2Api.java
@@ -43,13 +43,14 @@ public interface OAuth2Api {
 			summary = "OAuth2 로그인",
 			description =
 					"credentials를 검증하고 clientType에 따라 분기한다. "
-							+ "WEB: eeos_access_token / eeos_refresh_token 쿠키 설정 후 303 redirect. "
-							+ "APP: authorization_code 발급 후 303 redirect. "
-							+ "credentials 실패 시 로그인 페이지로 303 redirect (error=invalid_credentials).")
+							+ "WEB: eeos_access_token / eeos_refresh_token 쿠키 설정 후 200 + { \"redirectUrl\": \"...\" } 반환. "
+							+ "APP: authorization_code 발급 후 200 + { \"redirectUrl\": \"...\" } 반환. "
+							+ "클라이언트가 redirectUrl로 window.location.href 이동해야 한다. "
+							+ "credentials 실패 시 200 + { \"redirectUrl\": \"...\", \"error\": \"invalid_credentials\" } 반환.")
 	@ApiResponses({
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-				responseCode = "303",
-				description = "인증 성공 후 redirect_uri로 리다이렉트"),
+				responseCode = "200",
+				description = "인증 처리 완료. redirectUrl로 클라이언트가 직접 이동해야 함"),
 		@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "400",
 				description =
@@ -63,7 +64,7 @@ public interface OAuth2Api {
 				description = "| 코드 | 메시지 |\n" + "|------|--------|\n" + "| 4290 | 로그인 시도 횟수를 초과했습니다 |",
 				content = @Content)
 	})
-	ResponseEntity<Void> login(
+	ResponseEntity<Map<String, String>> login(
 			@Parameter(description = "클라이언트 ID", required = true) String clientId,
 			@Parameter(description = "리다이렉트 URI", required = true) String redirectUri,
 			@Parameter(description = "CSRF 방지용 상태값", required = true) String state,

--- a/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2ControllerTest.java
+++ b/eeos/src/test/java/com/blackcompany/eeos/auth/presentation/controller/OAuth2ControllerTest.java
@@ -98,7 +98,7 @@ class OAuth2ControllerTest {
 			when(clientService.findAndValidateRedirectUri("bad", "http://x"))
 					.thenThrow(new InvalidClientException());
 
-			ResponseEntity<Void> result =
+			ResponseEntity<Map<String, String>> result =
 					controller.login(
 							"bad",
 							"http://x",
@@ -114,8 +114,8 @@ class OAuth2ControllerTest {
 		}
 
 		@Test
-		@DisplayName("WEB 클라이언트 로그인 성공 시 쿠키 설정 + 303 리다이렉트")
-		void web_login_sets_cookies_and_redirects() {
+		@DisplayName("WEB 클라이언트 로그인 성공 시 쿠키 설정 + 200 + redirectUrl 반환")
+		void web_login_sets_cookies_and_returns_redirect_url() {
 			ClientEntity webClient =
 					ClientEntity.builder().clientId("web1").clientType(ClientType.WEB).build();
 			when(clientService.findAndValidateRedirectUri("web1", "http://web/callback"))
@@ -139,7 +139,7 @@ class OAuth2ControllerTest {
 			request.setRemoteAddr("127.0.0.1");
 			MockHttpServletResponse response = new MockHttpServletResponse();
 
-			ResponseEntity<Void> result =
+			ResponseEntity<Map<String, String>> result =
 					controller.login(
 							"web1",
 							"http://web/callback",
@@ -151,15 +151,15 @@ class OAuth2ControllerTest {
 							request,
 							response);
 
-			assertEquals(HttpStatus.SEE_OTHER, result.getStatusCode());
-			assertTrue(
-					result.getHeaders().get(HttpHeaders.LOCATION).get(0).contains("http://web/callback"));
+			assertEquals(HttpStatus.OK, result.getStatusCode());
+			assertTrue(result.getBody().get("redirectUrl").contains("http://web/callback"));
+			assertTrue(result.getBody().get("redirectUrl").contains("state=state1"));
 			assertTrue(response.getHeader(HttpHeaders.SET_COOKIE).contains("eeos_access_token"));
 		}
 
 		@Test
-		@DisplayName("APP 클라이언트 로그인 성공 시 authorization_code + 303 리다이렉트")
-		void app_login_returns_code_and_redirects() {
+		@DisplayName("APP 클라이언트 로그인 성공 시 200 + redirectUrl(authorization_code 포함) 반환")
+		void app_login_returns_redirect_url_with_code() {
 			ClientEntity appClient =
 					ClientEntity.builder().clientId("app1").clientType(ClientType.APP).build();
 			when(clientService.findAndValidateRedirectUri("app1", "http://app/callback"))
@@ -177,7 +177,7 @@ class OAuth2ControllerTest {
 			MockHttpServletRequest request = new MockHttpServletRequest();
 			request.setRemoteAddr("127.0.0.1");
 
-			ResponseEntity<Void> result =
+			ResponseEntity<Map<String, String>> result =
 					controller.login(
 							"app1",
 							"http://app/callback",
@@ -189,9 +189,9 @@ class OAuth2ControllerTest {
 							request,
 							new MockHttpServletResponse());
 
-			assertEquals(HttpStatus.SEE_OTHER, result.getStatusCode());
-			assertTrue(
-					result.getHeaders().get(HttpHeaders.LOCATION).get(0).contains("code=auth-code-123"));
+			assertEquals(HttpStatus.OK, result.getStatusCode());
+			assertTrue(result.getBody().get("redirectUrl").contains("code=auth-code-123"));
+			assertTrue(result.getBody().get("redirectUrl").contains("state=state1"));
 		}
 	}
 


### PR DESCRIPTION
## 개요

브라우저에서 `POST /api/v2/auth/login`을 XHR/fetch로 호출했을 때 CORS 에러가 발생했다.
근본 원인은 Fetch 스펙의 **크로스 오리진 리다이렉트 시 `Origin: null` 교체** 동작이다.
`auth.econovation.kr`에 CORS 헤더를 추가해도 오리진이 `null`로 바뀌어 영원히 실패하는 구조였다.

`303 리다이렉트` 대신 `200 + { "redirectUrl": "..." }`을 반환하고, FE가 `window.location.href`로 브라우저 레벨 이동을 수행하도록 변경한다.

---

## 왜 에러가 났는가

```
┌─────────────────────────────────────────────────────────────────┐
│  기존 흐름 (BROKEN)                                              │
└─────────────────────────────────────────────────────────────────┘

① FE (auth-econovation-fe.vercel.app)
   └─ XHR/fetch → POST api.eeos.econovation.kr/api/v2/auth/login
                   Origin: https://auth-econovation-fe.vercel.app  ✅

② BE → 303 SEE OTHER
        Location: https://auth.econovation.kr?state=...

③ 브라우저가 자동으로 리다이렉트를 따라감
   └─ GET https://auth.econovation.kr?state=...
        Origin: null  ← ⚠️ Fetch 스펙: 크로스 오리진 리다이렉트 시 null로 교체

④ auth.econovation.kr
   Access-Control-Allow-Origin: https://auth-econovation-fe.vercel.app
   → "null" 과 불일치 → CORS 에러 ❌

   ※ auth.econovation.kr에 CORS 헤더를 아무리 추가해도 해결 불가
```

---

## 왜 이 방법으로 해결되는가

```
┌─────────────────────────────────────────────────────────────────┐
│  변경 후 흐름 (FIXED)                                            │
└─────────────────────────────────────────────────────────────────┘

① FE (auth-econovation-fe.vercel.app)
   └─ XHR/fetch → POST api.eeos.econovation.kr/api/v2/auth/login
                   Origin: https://auth-econovation-fe.vercel.app  ✅

② BE → 200 OK  (리다이렉트 없음)
        Set-Cookie: eeos_access_token=...  (domain=.econovation.kr)
        Set-Cookie: eeos_refresh_token=...
        Body: { "redirectUrl": "https://auth.econovation.kr?state=..." }

③ FE가 직접 브라우저 이동
   └─ window.location.href = "https://auth.econovation.kr?state=..."
      ↳ 브라우저 레벨 네비게이션 → CORS 검사 자체가 없음 ✅

④ auth.econovation.kr 도달
   └─ .econovation.kr 공유 쿠키 자동 포함 ✅
```

---

## 영향 범위

**프론트엔드:** `POST /api/v2/auth/login` 응답 처리 로직 변경 필수.
- 기존: 서버 리다이렉트를 그대로 따라감
- 변경 후: 응답 JSON의 `redirectUrl`을 읽어 `window.location.href = redirectUrl` 수행
- 로그인 실패 시: 응답 body에 `"error": "invalid_credentials"` 키가 함께 포함됨

**WEB/APP 공통 적용:** WEB(쿠키 방식)과 APP(PKCE authorization code) 모두 동일하게 `200 + redirectUrl` 반환으로 변경됨.

---

## 배포 전 필수 확인

- [ ] FE 팀이 `POST /api/v2/auth/login` 응답 처리를 `window.location.href = redirectUrl` 방식으로 변경했는지 확인
- [ ] `COOKIE_TOKEN_DOMAIN=.econovation.kr` 설정 여부 확인 (WEB 타입 쿠키가 `auth.econovation.kr`에서 읽혀야 하므로)
- [ ] BE 배포 후 FE 배포 순서 준수 (순서 반대 시 기존 303 처리 코드가 잘못된 응답을 처리하게 됨)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * OAuth2 로그인 응답 형식이 리다이렉트 기반에서 JSON 기반으로 변경되었습니다. 클라이언트는 응답 본문의 `redirectUrl`을 받아 직접 처리하면 됩니다.

* **Bug Fixes**
  * 로그인 및 에러 응답이 구조화된 JSON 형식으로 개선되어 에러 정보를 보다 명확하게 전달합니다.

* **Documentation**
  * API 문서가 새로운 응답 형식 및 처리 흐름을 반영하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->